### PR TITLE
fix(deploy): restore dashboard access for direct-LAN deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,34 @@ WATCHER_FILE_PATTERN=*.xml
 DOZZLE_PORT=8081
 
 # =============================================================================
+# Security (v1.3.0 — security hardening)
+# =============================================================================
+# TrustedProxy::guard() rejects any request whose REMOTE_ADDR isn't in this list.
+# - Behind a reverse proxy (Caddy/nginx on the host): set to the proxy's IP
+#   only (e.g. 127.0.0.1/32,::1/128 for a same-host proxy, or the docker
+#   bridge gateway for a containerized one).
+# - Direct-LAN deployment with no proxy: widen this to your LAN CIDR (e.g.
+#   10.0.0.0/8) or 0.0.0.0/0,::/0 to disable the guard.
+TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128
+
+# CORS allowlist for /api/* (comma-separated origins). Empty = same-origin only.
+# Example: ALLOWED_ORIGINS=https://dashboard.example.com,https://ops.example.com
+ALLOWED_ORIGINS=
+
+# Header name a trusted upstream uses to pass the authenticated user. Read by
+# Identity::extract() and validated against ^[A-Za-z0-9._@-]{1,64}$. Ignored
+# unless REMOTE_ADDR is in TRUSTED_PROXY_CIDRS.
+PROXY_IDENTITY_HEADER=X-Auth-User
+
+# Notification base-URL allowlist (comma-separated host substrings). Empty
+# disables the allowlist. Example: NOTIFICATION_BASE_URL_ALLOWLIST=ntfy.example.com,api.pushover.net
+NOTIFICATION_BASE_URL_ALLOWLIST=
+
+# Allow http:// (not https://) for notification channels whose host is private
+# (RFC1918 / loopback). Public hosts are always required to be https.
+NOTIFICATION_ALLOW_HTTP_PRIVATE=false
+
+# =============================================================================
 # Notifications (v1.2.0 — nws-endpoints consolidation)
 # =============================================================================
 # Delta-time gate: events older than this many seconds are NOT notified.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
         TZ: ${TZ:-UTC}
     container_name: nws-cad-api
     ports:
-      - "127.0.0.1:8080:8080"
+      - "${API_PORT:-8080}:8080"
     volumes:
       - ./public:/var/www/public
       - ./src:/var/www/src


### PR DESCRIPTION
## Summary

- Document the five new security env vars introduced in v1.3.0 (TRUSTED_PROXY_CIDRS, ALLOWED_ORIGINS, PROXY_IDENTITY_HEADER, NOTIFICATION_BASE_URL_ALLOWLIST, NOTIFICATION_ALLOW_HTTP_PRIVATE) in `.env.example` with guidance for both proxy-fronted and direct-LAN topologies
- Revert API container port from `127.0.0.1:8080:8080` back to `${API_PORT:-8080}:8080`. The defense-in-depth loopback bind assumed a reverse proxy in front, but direct-LAN deployments lost dashboard access entirely

## Why

After the v1.3.0 security hardening merge, browsing to `:8080/` on a LAN-deployed install returned `403 Direct access not permitted` from `TrustedProxy::guard()` (no `TRUSTED_PROXY_CIDRS` set, defaulted to loopback only). The new env vars were also not documented in `.env.example`, so operators had no migration path.

For direct-LAN deployments (no reverse proxy), set `TRUSTED_PROXY_CIDRS=0.0.0.0/0,::/0` in `.env`. For proxy-fronted deployments, the loopback bind can be added back by overriding `API_PORT` or via `docker-compose.override.yml`.

## Test plan

- [x] Verified locally: `curl http://10.200.4.27:8080/api/health` returns 200 with `db:ok`
- [x] Verified locally: dashboard root `/` loads with HTTP 200
- [ ] No automated test impact — config + docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)