### PR TITLE
feat(notifications): ChannelRegistry + WebhookChannel for plug-in transports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,11 @@ PUSHOVER_TOKEN=
 PUSHOVER_USER=
 PUSHOVER_BASE_URL=https://api.pushover.net/1/messages.json
 
+# Webhook channels (enable via `php bin/notifications.php enable webhook ...`)
+# do NOT require a global env var. Per-row auth lives in
+# notification_channels.config_json: { "auth_header": "Authorization",
+# "auth_token_env": "MY_WEBHOOK_TOKEN" }.
+
 # =============================================================================
 # Call status guardrail
 # =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,6 +339,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `ChannelRegistry` and `ChannelDescriptor` for plug-in channel registration. Adding a new channel type now requires one class with a `descriptor()` static method plus one line in `src/Notifications/registerChannels.php`.
+- `WebhookChannel` — generic HTTP POST channel with JSON-template payload configuration. Covers Slack, Discord, Mattermost, Home Assistant, and similar incoming-webhook integrations via per-row `config_json` templates with `{string}` and `"${array}"` placeholder substitution.
+- `HttpPost::postJson()` helper for JSON-body HTTP POST.
 - Unified filter system across desktop dashboard, mobile dashboard, and new `/calls` and `/units` list pages.
 - New filter vocabulary: call_type, incident_type, nature_of_call (LIKE), agency, ORI, FDID, beat, area, city, location, call_id, unit #, status (open/closed/canceled), and date range with presets.
 - New `Api\Filtering\` namespace (`FilterCriteria`, `FilterSqlBuilder`, `FilterRegistry`, `FilterContext`, `FilterOptionsCache`, `DateRange`, `InvalidFilterException`).
@@ -349,16 +352,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vendored frontend libraries: Choices.js v10 and Flatpickr v4 under `public/assets/vendor/`.
 - Notifications dashboard UI: enable/disable channels and dispatch synthetic test sends from `/notifications` without dropping into the shell. Backed by three new endpoints (`POST /api/notifications/channels/{type}/{enable|disable|test}`) and a shared `Notifications\ChannelFactory` for channel construction.
 
+### Changed
+- `ChannelFactory::create()` now dispatches via `ChannelRegistry` instead of a hardcoded `match` on channel type.
+- `NotificationsController` and `bin/notifications.php` query the registry for validation, help text, and default `config_json` on first enable.
+- The `/api/notifications/{type}/enable|disable|test|clear` endpoints now return HTTP 400 (was 404) for unknown channel types, with the available types listed in `errors.available_types`.
+- Consolidated v1.1.0 database migration scripts into init.sql files (migrations already reflected in init schemas)
+- Removed redundant `database/mysql/migration_v1.1.0.sql` and `database/postgres/migration_v1.1.0.sql`
+- Removed orphaned `data/dbeaver` directory references (no DBeaver service in docker-compose.yml)
+
 ### Removed
+- Unused `NotificationChannel::type()` interface method (`descriptor()->type` replaces it).
 - Legacy `public/assets/js/filter-manager.js` (replaced by `FilterPanel`).
 - Mobile filter logic in `mobile.js` (replaced by `FilterPanel` compact mode).
 - `Api\Request::filters()` (superseded by `FilterCriteria`).
 - `partials/filter-modal.php` and `partials-mobile/filters-modal.php` (replaced by `partials/filter-panel.php`).
-
-### Changed
-- Consolidated v1.1.0 database migration scripts into init.sql files (migrations already reflected in init schemas)
-- Removed redundant `database/mysql/migration_v1.1.0.sql` and `database/postgres/migration_v1.1.0.sql`
-- Removed orphaned `data/dbeaver` directory references (no DBeaver service in docker-compose.yml)
 
 ### Security (2026-02-15)
 - 🔒 **Critical XSS Fixes** - Comprehensive cross-site scripting prevention across all JavaScript

--- a/bin/notifications.php
+++ b/bin/notifications.php
@@ -12,21 +12,26 @@ $args = $_SERVER['argv'] ?? [];
 array_shift($args);
 $cmd = $args[0] ?? 'help';
 
+$availableTypes = implode('|', \NwsCad\Notifications\ChannelRegistry::types());
+$envBlock = '';
+foreach (\NwsCad\Notifications\ChannelRegistry::all() as $descriptor) {
+    $envBlock .= "  {$descriptor->type}: " . implode(', ', $descriptor->requiredEnvs) . "\n";
+}
+
 function help(): never
 {
+    global $availableTypes, $envBlock;
     echo <<<TXT
 Usage: php bin/notifications.php <command>
 
 Commands:
   list                                 Show all channels with status.
-  enable <type> [--base-url=URL]       Enable (or create) a channel of the given type ('ntfy'|'pushover').
+  enable <type> [--base-url=URL]       Enable (or create) a channel of the given type ('{$availableTypes}').
   disable <type>                       Disable all channels of the given type.
   test <type>                          Send a synthetic notification through the first enabled channel of <type>.
 
 Secrets are read from environment (.env). Required env vars per type:
-  ntfy:     NTFY_AUTH_TOKEN
-  pushover: PUSHOVER_TOKEN, PUSHOVER_USER
-
+{$envBlock}
 TXT;
     exit(0);
 }
@@ -49,8 +54,8 @@ switch ($cmd) {
 
     case 'enable':
         $type = $args[1] ?? null;
-        if (! in_array($type, ['ntfy', 'pushover'], true)) {
-            fwrite(STDERR, "enable requires <type> = ntfy | pushover\n");
+        if (! \NwsCad\Notifications\ChannelRegistry::has($type)) {
+            fwrite(STDERR, "Unknown channel type: {$type}. Available: " . implode(', ', \NwsCad\Notifications\ChannelRegistry::types()) . "\n");
             exit(1);
         }
         $baseUrl = '';
@@ -60,7 +65,7 @@ switch ($cmd) {
             }
         }
         if ($baseUrl === '') {
-            $envKey = $type === 'ntfy' ? 'NTFY_BASE_URL' : 'PUSHOVER_BASE_URL';
+            $envKey = \NwsCad\Notifications\ChannelRegistry::get($type)->baseUrlEnv;
             $baseUrl = $_ENV[$envKey] ?? getenv($envKey) ?: '';
             if ($baseUrl === '') {
                 fwrite(STDERR, "Provide --base-url=URL or set {$envKey} in environment.\n");
@@ -77,9 +82,7 @@ switch ($cmd) {
             exit(1);
         }
 
-        $defaultConfig = $type === 'ntfy'
-            ? '{"auth_token_env":"NTFY_AUTH_TOKEN","alarm_priority_map":{"1":3,"2":4,"3":5}}'
-            : '{"token_env":"PUSHOVER_TOKEN","user_env":"PUSHOVER_USER"}';
+        $defaultConfig = json_encode(\NwsCad\Notifications\ChannelRegistry::get($type)->defaultConfig);
 
         $db = Database::getConnection();
         $name = "{$type}_primary";
@@ -99,8 +102,8 @@ switch ($cmd) {
 
     case 'disable':
         $type = $args[1] ?? null;
-        if (! in_array($type, ['ntfy', 'pushover'], true)) {
-            fwrite(STDERR, "disable requires <type>\n");
+        if (! \NwsCad\Notifications\ChannelRegistry::has($type)) {
+            fwrite(STDERR, "Unknown channel type: {$type}. Available: " . implode(', ', \NwsCad\Notifications\ChannelRegistry::types()) . "\n");
             exit(1);
         }
         $db = Database::getConnection();

--- a/bin/notifications.php
+++ b/bin/notifications.php
@@ -4,6 +4,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../src/Notifications/registerChannels.php';
 
 use NwsCad\Database;
 

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -105,6 +105,90 @@ Every send attempt that produces a permanent outcome writes a `notification_send
 | Inspect channel state in DB   | `SELECT * FROM notification_channels;`                                        |
 | Inspect recent sends in DB    | `SELECT * FROM notification_send_log ORDER BY id DESC LIMIT 20;`              |
 
+## Webhook channel
+
+The `webhook` channel emits one HTTP POST per `CallProcessedEvent`. The payload is a JSON object built from a per-row template stored in `notification_channels.config_json`. Covers Slack, Discord, Mattermost, Home Assistant, and similar incoming-webhook integrations via configuration alone — no PHP changes are needed to add a new platform.
+
+### Enable a webhook channel
+
+CLI:
+
+```bash
+php bin/notifications.php enable webhook --base-url=https://hooks.slack.com/services/...
+```
+
+API equivalent:
+
+```http
+POST /api/notifications/webhook/enable
+Content-Type: application/json
+
+{ "base_url": "https://hooks.slack.com/services/..." }
+```
+
+The channel is created with a sensible default `template`, but you will usually want to edit `config_json` afterward to customize it for your platform.
+
+### Template syntax
+
+Two kinds of placeholder are supported:
+
+- `{name}` — **string substitution**. The placeholder is replaced inline within any string-valued leaf of the template. Available tokens: `{intent}`, `{call_id}`, `{call_number}`, `{call_type}`, `{full_address}`, `{create_datetime}`, `{alarm_level}`, `{narrative}`, `{agency_type}`, `{jurisdiction}`, `{units}`, `{topics}` (comma-joined).
+- `"${name}"` — **raw JSON array**. Must appear as the entire string value of a JSON field (surrounding quotes included). After substitution the quoted placeholder becomes a real JSON array literal. Available tokens: `${topics}`, `${units}`, `${jurisdiction}`.
+
+Unknown placeholders pass through literally; they are not an error.
+
+### Slack example
+
+```json
+{
+  "template": {
+    "text": ":rotating_light: *{call_type}* at {full_address}",
+    "attachments": [
+      {
+        "fields": [
+          {"title": "Intent",  "value": "{intent}", "short": true},
+          {"title": "Topics",  "value": "{topics}", "short": true},
+          {"title": "Units",   "value": "{units}",  "short": false}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Apply via SQL:
+
+```sql
+UPDATE notification_channels
+SET config_json = '{ "template": { ... } }'
+WHERE name = 'webhook_slack';
+```
+
+Or edit the row through the admin UI or `bin/notifications.php`.
+
+### Discord example
+
+```json
+{
+  "template": {
+    "content": "**{call_type}** — {full_address}\nIntent: {intent}\nTopics: {topics}"
+  }
+}
+```
+
+### Authentication
+
+If the receiver requires a bearer token or API key, add two keys to `config_json`:
+
+- `auth_header` — the header name (e.g., `Authorization`, `X-Api-Key`).
+- `auth_token_env` — the env-var **name** holding the token (e.g., `WEBHOOK_AUTH_TOKEN`).
+
+At send time the channel reads the secret via `Config::secret($auth_token_env)`, registers it with `SecretRegistry` so the global `RedactingProcessor` scrubs it from logs, and sets the header. Tokens containing CR or LF are rejected at channel construction.
+
+### Retry semantics
+
+Same as ntfy and Pushover: 4 attempts total (initial + 3 retries, 1 s / 3 s / 9 s backoff). 2xx = success; 4xx = permanent failure (no retry); 5xx and network errors are retried. After exhaustion the channel's `last_error` is updated and a single `SendResult::fail` is recorded in `notification_send_log`.
+
 ## Adding a new channel type
 
-Implement `NwsCad\Notifications\NotificationChannel`, return a fresh `type()` string, and extend the `channelFactory` closure in `src/watcher.php`. Add a unit test under `tests/Unit/Notifications/Channels/`.
+Register a class that implements `NwsCad\Notifications\NotificationChannel` and add a `descriptor()` static method returning a `ChannelDescriptor`. Then add one line in `src/Notifications/registerChannels.php` to register it with `ChannelRegistry`. Add a unit test under `tests/Unit/Notifications/Channels/`.

--- a/docs/superpowers/plans/2026-05-12-channel-registry.md
+++ b/docs/superpowers/plans/2026-05-12-channel-registry.md
@@ -1,0 +1,1846 @@
+# Channel Registry & WebhookChannel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hardcoded `['ntfy','pushover']` allowlist sprinkled across `ChannelFactory`, `NotificationsController`, and `bin/notifications.php` with a static `ChannelRegistry`, and ship `WebhookChannel` as the first consumer of the new abstraction.
+
+**Architecture:** Static `ChannelRegistry` holds one `ChannelDescriptor` per channel type. Each `NotificationChannel` implementer exposes a `descriptor()` static method that returns its registration record (type, label, env defaults, factory closure). A single `registerChannels.php` include wires the registry at boot in three sites: `src/watcher.php`, `src/bootstrap.php`, and `bin/notifications.php`. Schema is unchanged.
+
+**Tech Stack:** PHP 8.3 (strict types, readonly properties, first-class callables), PHPUnit 10.5 (with strict coverage metadata), Composer PSR-4 (`NwsCad\` from `src/`), MySQL 8 / PostgreSQL 16, Monolog logging.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-12-channel-registry-design.md`
+
+**Ordering invariants:**
+- Tasks 1–3 are pure additions: no production code path changes.
+- Task 4 wires the registry at boot but leaves the old factory match-statement intact.
+- Task 5 cuts over `ChannelFactory` to the registry — first task that changes behavior.
+- Tasks 6–7 cut over the API and CLI; each commit leaves the system working.
+- Task 8 removes the now-unused `type()` interface method (back-compat cleanup).
+- Tasks 9–12 add `WebhookChannel`.
+- Task 13 closes out docs and CHANGELOG.
+
+---
+
+### Task 1: ChannelDescriptor value object
+
+**Files:**
+- Create: `src/Notifications/ChannelDescriptor.php`
+- Create: `tests/Unit/Notifications/ChannelDescriptorTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Unit/Notifications/ChannelDescriptorTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications;
+
+use Closure;
+use NwsCad\Notifications\ChannelDescriptor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ChannelDescriptor::class)]
+final class ChannelDescriptorTest extends TestCase
+{
+    public function testReadonlyPropertiesExposeConstructorArgs(): void
+    {
+        $factory = static fn (array $r, $cfg) => new \stdClass();
+
+        $d = new ChannelDescriptor(
+            type:          'demo',
+            label:         'Demo Channel',
+            baseUrlEnv:    'DEMO_BASE_URL',
+            requiredEnvs:  ['DEMO_TOKEN'],
+            defaultConfig: ['key' => 'value'],
+            factory:       $factory,
+        );
+
+        $this->assertSame('demo', $d->type);
+        $this->assertSame('Demo Channel', $d->label);
+        $this->assertSame('DEMO_BASE_URL', $d->baseUrlEnv);
+        $this->assertSame(['DEMO_TOKEN'], $d->requiredEnvs);
+        $this->assertSame(['key' => 'value'], $d->defaultConfig);
+        $this->assertInstanceOf(Closure::class, $d->factory);
+    }
+
+    public function testFactoryClosureIsInvokable(): void
+    {
+        $marker = new \stdClass();
+        $factory = static fn (array $row, $cfg): object => $marker;
+
+        $d = new ChannelDescriptor(
+            type: 't', label: 'l', baseUrlEnv: 'E',
+            requiredEnvs: [], defaultConfig: [],
+            factory: $factory,
+        );
+
+        $result = ($d->factory)(['type' => 't'], null);
+        $this->assertSame($marker, $result);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/ChannelDescriptorTest.php`
+Expected: FAIL with `Class "NwsCad\Notifications\ChannelDescriptor" not found`.
+
+- [ ] **Step 3: Create the value object**
+
+Create `src/Notifications/ChannelDescriptor.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Notifications;
+
+use Closure;
+
+/**
+ * Immutable registration record for a notification channel type.
+ *
+ * Each channel class exposes a static `descriptor()` returning one of these;
+ * `registerChannels.php` registers them all at boot, and ChannelRegistry holds
+ * them for the rest of the request/process lifetime.
+ */
+final class ChannelDescriptor
+{
+    /**
+     * @param string[]            $requiredEnvs Env-var names that must be present when the channel is enabled.
+     * @param array<string,mixed> $defaultConfig Becomes notification_channels.config_json on first enable.
+     * @param Closure(array<string,mixed>, \NwsCad\Config): NotificationChannel $factory
+     *        Builds an instance of the channel from a DB row and the current Config.
+     */
+    public function __construct(
+        public readonly string  $type,
+        public readonly string  $label,
+        public readonly string  $baseUrlEnv,
+        public readonly array   $requiredEnvs,
+        public readonly array   $defaultConfig,
+        public readonly Closure $factory,
+    ) {
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/ChannelDescriptorTest.php`
+Expected: PASS (2 tests, 6 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Notifications/ChannelDescriptor.php tests/Unit/Notifications/ChannelDescriptorTest.php
+git commit -m "feat(notifications): add ChannelDescriptor value object"
+```
+
+---
+
+### Task 2: ChannelRegistry static container
+
+**Files:**
+- Create: `src/Notifications/ChannelRegistry.php`
+- Create: `tests/Unit/Notifications/ChannelRegistryTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Unit/Notifications/ChannelRegistryTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications;
+
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\ChannelRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ChannelRegistry::class)]
+#[UsesClass(ChannelDescriptor::class)]
+final class ChannelRegistryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ChannelRegistry::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        ChannelRegistry::clear();
+    }
+
+    private function descriptor(string $type): ChannelDescriptor
+    {
+        return new ChannelDescriptor(
+            type: $type, label: ucfirst($type),
+            baseUrlEnv: strtoupper($type) . '_BASE_URL',
+            requiredEnvs: [], defaultConfig: [],
+            factory: static fn (array $r, $c) => new \stdClass(),
+        );
+    }
+
+    public function testEmptyRegistry(): void
+    {
+        $this->assertSame([], ChannelRegistry::types());
+        $this->assertSame([], ChannelRegistry::all());
+        $this->assertFalse(ChannelRegistry::has('ntfy'));
+        $this->assertNull(ChannelRegistry::get('ntfy'));
+    }
+
+    public function testRegisterAndRetrieve(): void
+    {
+        $d = $this->descriptor('demo');
+        ChannelRegistry::register($d);
+
+        $this->assertTrue(ChannelRegistry::has('demo'));
+        $this->assertSame($d, ChannelRegistry::get('demo'));
+        $this->assertSame(['demo'], ChannelRegistry::types());
+        $this->assertSame(['demo' => $d], ChannelRegistry::all());
+    }
+
+    public function testDuplicateTypeOverwrites(): void
+    {
+        $first  = $this->descriptor('demo');
+        $second = $this->descriptor('demo');
+        ChannelRegistry::register($first);
+        ChannelRegistry::register($second);
+
+        $this->assertSame($second, ChannelRegistry::get('demo'));
+        $this->assertCount(1, ChannelRegistry::all());
+    }
+
+    public function testClearWipesState(): void
+    {
+        ChannelRegistry::register($this->descriptor('a'));
+        ChannelRegistry::register($this->descriptor('b'));
+        ChannelRegistry::clear();
+
+        $this->assertSame([], ChannelRegistry::types());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/ChannelRegistryTest.php`
+Expected: FAIL with `Class "NwsCad\Notifications\ChannelRegistry" not found`.
+
+- [ ] **Step 3: Create the registry**
+
+Create `src/Notifications/ChannelRegistry.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Notifications;
+
+/**
+ * Static registry of channel descriptors. Populated by registerChannels.php
+ * at boot of every entry point (watcher, HTTP, CLI). Queried by
+ * ChannelFactory at dispatch time and by the API/CLI for validation and help.
+ *
+ * Static state is intentional given PHP's per-request lifecycle; tests MUST
+ * call `clear()` in tearDown to prevent state leak between tests.
+ */
+final class ChannelRegistry
+{
+    /** @var array<string, ChannelDescriptor> */
+    private static array $byType = [];
+
+    public static function register(ChannelDescriptor $d): void
+    {
+        self::$byType[$d->type] = $d;
+    }
+
+    public static function get(string $type): ?ChannelDescriptor
+    {
+        return self::$byType[$type] ?? null;
+    }
+
+    public static function has(string $type): bool
+    {
+        return isset(self::$byType[$type]);
+    }
+
+    /** @return string[] */
+    public static function types(): array
+    {
+        return array_keys(self::$byType);
+    }
+
+    /** @return array<string, ChannelDescriptor> */
+    public static function all(): array
+    {
+        return self::$byType;
+    }
+
+    public static function clear(): void
+    {
+        self::$byType = [];
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/ChannelRegistryTest.php`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Notifications/ChannelRegistry.php tests/Unit/Notifications/ChannelRegistryTest.php
+git commit -m "feat(notifications): add ChannelRegistry static container"
+```
+
+---
+
+### Task 3: Add `descriptor()` to NtfyChannel and PushoverChannel
+
+The interface still has `type()` at this point. We add `descriptor()` as a new static on the concrete classes WITHOUT touching the interface yet — keeps the system working while we wire things up. Task 8 removes the now-unused `type()` after all consumers have migrated.
+
+**Files:**
+- Modify: `src/Notifications/Channels/NtfyChannel.php` (add `descriptor()` static)
+- Modify: `src/Notifications/Channels/PushoverChannel.php` (add `descriptor()` static)
+- Create: `tests/Unit/Notifications/Channels/NtfyChannelDescriptorTest.php`
+- Create: `tests/Unit/Notifications/Channels/PushoverChannelDescriptorTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Unit/Notifications/Channels/NtfyChannelDescriptorTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications\Channels;
+
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\Channels\NtfyChannel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NtfyChannel::class)]
+#[UsesClass(ChannelDescriptor::class)]
+final class NtfyChannelDescriptorTest extends TestCase
+{
+    public function testDescriptorReportsTypeAndDefaults(): void
+    {
+        $d = NtfyChannel::descriptor();
+
+        $this->assertInstanceOf(ChannelDescriptor::class, $d);
+        $this->assertSame('ntfy', $d->type);
+        $this->assertSame('ntfy.sh', $d->label);
+        $this->assertSame('NTFY_BASE_URL', $d->baseUrlEnv);
+        $this->assertSame(['NTFY_AUTH_TOKEN'], $d->requiredEnvs);
+        $this->assertSame(['auth_token_env' => 'NTFY_AUTH_TOKEN'], $d->defaultConfig);
+    }
+}
+```
+
+Create `tests/Unit/Notifications/Channels/PushoverChannelDescriptorTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications\Channels;
+
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\Channels\PushoverChannel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PushoverChannel::class)]
+#[UsesClass(ChannelDescriptor::class)]
+final class PushoverChannelDescriptorTest extends TestCase
+{
+    public function testDescriptorReportsTypeAndDefaults(): void
+    {
+        $d = PushoverChannel::descriptor();
+
+        $this->assertInstanceOf(ChannelDescriptor::class, $d);
+        $this->assertSame('pushover', $d->type);
+        $this->assertSame('Pushover', $d->label);
+        $this->assertSame('PUSHOVER_BASE_URL', $d->baseUrlEnv);
+        $this->assertSame(['PUSHOVER_TOKEN', 'PUSHOVER_USER'], $d->requiredEnvs);
+        $this->assertSame(
+            ['token_env' => 'PUSHOVER_TOKEN', 'user_env' => 'PUSHOVER_USER'],
+            $d->defaultConfig,
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/Channels/NtfyChannelDescriptorTest.php tests/Unit/Notifications/Channels/PushoverChannelDescriptorTest.php`
+Expected: FAIL with `Call to undefined method ... descriptor()`.
+
+- [ ] **Step 3: Add `descriptor()` to NtfyChannel**
+
+In `src/Notifications/Channels/NtfyChannel.php`, locate the existing `public static function type(): string` (around line ~25) and add this method immediately after it. Also add the `use NwsCad\Config;` and `use NwsCad\Notifications\ChannelDescriptor;` and `use NwsCad\Notifications\NotificationChannel;` use-statements at the top if missing.
+
+```php
+public static function descriptor(): ChannelDescriptor
+{
+    return new ChannelDescriptor(
+        type:          'ntfy',
+        label:         'ntfy.sh',
+        baseUrlEnv:    'NTFY_BASE_URL',
+        requiredEnvs:  ['NTFY_AUTH_TOKEN'],
+        defaultConfig: ['auth_token_env' => 'NTFY_AUTH_TOKEN'],
+        factory: static function (array $row, Config $cfg): NotificationChannel {
+            $raw    = $row['config_json'] ?? '';
+            $config = $raw !== '' ? (json_decode($raw, true) ?: []) : [];
+            return new self(
+                baseUrl:   (string) $row['base_url'],
+                authToken: $cfg->secret($config['auth_token_env'] ?? 'NTFY_AUTH_TOKEN'),
+                config:    $config,
+            );
+        },
+    );
+}
+```
+
+- [ ] **Step 4: Add `descriptor()` to PushoverChannel**
+
+Same pattern in `src/Notifications/Channels/PushoverChannel.php` (add use-statements + method):
+
+```php
+public static function descriptor(): ChannelDescriptor
+{
+    return new ChannelDescriptor(
+        type:          'pushover',
+        label:         'Pushover',
+        baseUrlEnv:    'PUSHOVER_BASE_URL',
+        requiredEnvs:  ['PUSHOVER_TOKEN', 'PUSHOVER_USER'],
+        defaultConfig: ['token_env' => 'PUSHOVER_TOKEN', 'user_env' => 'PUSHOVER_USER'],
+        factory: static function (array $row, Config $cfg): NotificationChannel {
+            $raw    = $row['config_json'] ?? '';
+            $config = $raw !== '' ? (json_decode($raw, true) ?: []) : [];
+            return new self(
+                baseUrl: (string) $row['base_url'],
+                token:   $cfg->secret($config['token_env'] ?? 'PUSHOVER_TOKEN'),
+                user:    $cfg->secret($config['user_env']  ?? 'PUSHOVER_USER'),
+                config:  $config,
+            );
+        },
+    );
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/Channels/`
+Expected: PASS for both descriptor tests; all existing channel tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Notifications/Channels/NtfyChannel.php \
+        src/Notifications/Channels/PushoverChannel.php \
+        tests/Unit/Notifications/Channels/NtfyChannelDescriptorTest.php \
+        tests/Unit/Notifications/Channels/PushoverChannelDescriptorTest.php
+git commit -m "feat(notifications): add descriptor() to NtfyChannel and PushoverChannel"
+```
+
+---
+
+### Task 4: registerChannels.php boot file + boot test
+
+Creates the canonical channel-registration file and wires it into all three boot sites. Does NOT yet remove the hardcoded match in `ChannelFactory` — that's Task 5.
+
+**Files:**
+- Create: `src/Notifications/registerChannels.php`
+- Create: `tests/Unit/Notifications/RegisterChannelsBootTest.php`
+- Modify: `src/watcher.php` (add include)
+- Modify: `src/bootstrap.php` (add include)
+- Modify: `bin/notifications.php` (add include)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Unit/Notifications/RegisterChannelsBootTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications;
+
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\ChannelRegistry;
+use NwsCad\Notifications\Channels\NtfyChannel;
+use NwsCad\Notifications\Channels\PushoverChannel;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+#[UsesClass(ChannelRegistry::class)]
+#[UsesClass(ChannelDescriptor::class)]
+#[UsesClass(NtfyChannel::class)]
+#[UsesClass(PushoverChannel::class)]
+final class RegisterChannelsBootTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ChannelRegistry::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        ChannelRegistry::clear();
+    }
+
+    public function testIncludePopulatesRegistryWithNtfyAndPushover(): void
+    {
+        require __DIR__ . '/../../../src/Notifications/registerChannels.php';
+
+        $this->assertEqualsCanonicalizing(
+            ['ntfy', 'pushover'],
+            ChannelRegistry::types(),
+            'registerChannels.php must register the built-in channel types',
+        );
+    }
+}
+```
+
+(Task 11 will add `webhook` to this assertion. We assert exact membership so accidental drops fail the test.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/RegisterChannelsBootTest.php`
+Expected: FAIL with `Failed to open required ... registerChannels.php`.
+
+- [ ] **Step 3: Create registerChannels.php**
+
+Create `src/Notifications/registerChannels.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use NwsCad\Notifications\ChannelRegistry;
+use NwsCad\Notifications\Channels\NtfyChannel;
+use NwsCad\Notifications\Channels\PushoverChannel;
+
+ChannelRegistry::clear();
+ChannelRegistry::register(NtfyChannel::descriptor());
+ChannelRegistry::register(PushoverChannel::descriptor());
+```
+
+Note: deliberately not using `require_once` semantics — `clear()` makes re-inclusion safe and idempotent.
+
+- [ ] **Step 4: Wire into the three boot sites**
+
+In `src/watcher.php`, near the top after the autoload and Config initialization:
+
+```php
+require_once __DIR__ . '/Notifications/registerChannels.php';
+```
+
+In `src/bootstrap.php`, inside the existing IIFE after `Config::getInstance()`:
+
+```php
+require_once __DIR__ . '/Notifications/registerChannels.php';
+```
+
+In `bin/notifications.php`, after the autoload include:
+
+```php
+require_once __DIR__ . '/../src/Notifications/registerChannels.php';
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/RegisterChannelsBootTest.php`
+Expected: PASS.
+
+Also run the full unit suite to confirm no regression:
+Run: `composer test:unit`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Notifications/registerChannels.php \
+        src/watcher.php src/bootstrap.php bin/notifications.php \
+        tests/Unit/Notifications/RegisterChannelsBootTest.php
+git commit -m "feat(notifications): wire registerChannels.php into boot sites"
+```
+
+---
+
+### Task 5: Refactor ChannelFactory to use the registry
+
+First behavior change. The hardcoded `match` goes away; instantiation is delegated to the descriptor's factory closure.
+
+**Files:**
+- Modify: `src/Notifications/ChannelFactory.php`
+- Modify: `tests/Unit/Notifications/ChannelFactoryTest.php` (if it exists — refactor to use registry)
+
+- [ ] **Step 1: Inspect or create the existing factory test**
+
+Run: `ls tests/Unit/Notifications/ChannelFactoryTest.php`
+If it exists, read it to learn how the factory is tested. If it doesn't exist, create the test with this content:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications;
+
+use InvalidArgumentException;
+use NwsCad\Config;
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\ChannelFactory;
+use NwsCad\Notifications\ChannelRegistry;
+use NwsCad\Notifications\Channels\NtfyChannel;
+use NwsCad\Notifications\NotificationChannel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ChannelFactory::class)]
+#[UsesClass(ChannelRegistry::class)]
+#[UsesClass(ChannelDescriptor::class)]
+final class ChannelFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ChannelRegistry::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        ChannelRegistry::clear();
+    }
+
+    public function testUnknownTypeThrows(): void
+    {
+        $factory = new ChannelFactory(Config::getInstance());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown channel type: bogus');
+
+        $factory->create(['type' => 'bogus', 'base_url' => '', 'config_json' => '']);
+    }
+
+    public function testRegistryDispatchInvokesDescriptorFactory(): void
+    {
+        $stub = $this->createStub(NotificationChannel::class);
+
+        ChannelRegistry::register(new ChannelDescriptor(
+            type: 'demo', label: 'Demo', baseUrlEnv: 'DEMO_URL',
+            requiredEnvs: [], defaultConfig: [],
+            factory: static fn (array $row, Config $cfg): NotificationChannel => $stub,
+        ));
+
+        $factory = new ChannelFactory(Config::getInstance());
+        $result  = $factory->create([
+            'type'        => 'demo',
+            'base_url'    => 'http://example.test',
+            'config_json' => '{}',
+        ]);
+
+        $this->assertSame($stub, $result);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (or pass for old paths)**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/ChannelFactoryTest.php`
+Expected: `testUnknownTypeThrows` may currently pass with a different message; `testRegistryDispatchInvokesDescriptorFactory` FAILS because the factory still uses the hardcoded match (it won't find 'demo').
+
+- [ ] **Step 3: Refactor ChannelFactory::create()**
+
+Replace the entire body of `src/Notifications/ChannelFactory.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Notifications;
+
+use InvalidArgumentException;
+use NwsCad\Config;
+
+class ChannelFactory
+{
+    public function __construct(private readonly Config $config)
+    {
+    }
+
+    /**
+     * @param array{type:string,base_url:string,config_json:string} $row
+     */
+    public function create(array $row): NotificationChannel
+    {
+        $type = $row['type'] ?? '';
+        $d = ChannelRegistry::get($type)
+            ?? throw new InvalidArgumentException("Unknown channel type: {$type}");
+
+        return ($d->factory)($row, $this->config);
+    }
+}
+```
+
+Remove the now-unused `use NwsCad\Notifications\Channels\NtfyChannel;` and `use NwsCad\Notifications\Channels\PushoverChannel;` imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/ChannelFactoryTest.php`
+Expected: PASS.
+
+Also run the broader notification suite:
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Notifications/ChannelFactory.php tests/Unit/Notifications/ChannelFactoryTest.php
+git commit -m "refactor(notifications): ChannelFactory dispatches via ChannelRegistry"
+```
+
+---
+
+### Task 6: Refactor NotificationsController to use the registry
+
+**Files:**
+- Modify: `src/Api/Controllers/NotificationsController.php`
+- Modify: `tests/Integration/NotificationsApiTest.php` (add coverage for registry-driven validation)
+
+- [ ] **Step 1: Write the failing test**
+
+Open `tests/Integration/NotificationsApiTest.php` and add this new test (also add `@uses` for `ChannelRegistry` and `ChannelDescriptor` at the class level — typical PHPUnit attribute form):
+
+```php
+public function testEnableUnknownTypeReturnsAvailableTypes(): void
+{
+    \NwsCad\Notifications\ChannelRegistry::clear();
+    \NwsCad\Notifications\ChannelRegistry::register(\NwsCad\Notifications\Channels\NtfyChannel::descriptor());
+    \NwsCad\Notifications\ChannelRegistry::register(\NwsCad\Notifications\Channels\PushoverChannel::descriptor());
+
+    $_SERVER['REQUEST_METHOD'] = 'POST';
+
+    $controller = new \NwsCad\Api\Controllers\NotificationsController();
+    $controller->enable('badtype');
+
+    $response = $this->captureLastJsonResponse();
+    $this->assertSame(400, http_response_code());
+    $this->assertFalse($response['success']);
+    $this->assertSame(['ntfy', 'pushover'], $response['errors']['available_types']);
+}
+```
+
+If `captureLastJsonResponse()` doesn't already exist as a helper, add it: use `Response::resetForTesting()` in `setUp()` and `ob_start`/`ob_get_clean()` around the controller call to capture the JSON body, then `json_decode(..., true)`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter testEnableUnknownTypeReturnsAvailableTypes tests/Integration/NotificationsApiTest.php`
+Expected: FAIL — the response body won't yet contain `available_types`.
+
+- [ ] **Step 3: Refactor the controller**
+
+In `src/Api/Controllers/NotificationsController.php`:
+
+(a) Add use-statements near the top:
+```php
+use NwsCad\Notifications\ChannelRegistry;
+```
+
+(b) Replace the `validateType()` private method:
+```php
+private function validateType(string $type): bool
+{
+    return ChannelRegistry::has($type);
+}
+```
+
+(c) Replace any error response in `enable()`/`disable()`/`test()`/`clearChannelError()` that currently reads `'Invalid channel type'` so it includes the available list. The pattern:
+```php
+if (! $this->validateType($type)) {
+    Response::error('Invalid channel type', 400, [
+        'available_types' => ChannelRegistry::types(),
+    ]);
+    return;
+}
+```
+
+(d) Replace the hardcoded `defaultConfig` branch in `enable()`. Locate the block that currently looks like:
+```php
+$defaultConfig = $type === 'ntfy'
+    ? ['auth_token_env' => 'NTFY_AUTH_TOKEN']
+    : ['token_env' => 'PUSHOVER_TOKEN', 'user_env' => 'PUSHOVER_USER'];
+```
+
+Replace with:
+```php
+$descriptor    = ChannelRegistry::get($type);
+$defaultConfig = $descriptor->defaultConfig;
+```
+
+(The null check is unnecessary here — `validateType()` already returned true above.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./vendor/bin/phpunit tests/Integration/NotificationsApiTest.php`
+Expected: all existing tests + the new test pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Api/Controllers/NotificationsController.php tests/Integration/NotificationsApiTest.php
+git commit -m "refactor(notifications): API controller dispatches type validation via registry"
+```
+
+---
+
+### Task 7: Refactor bin/notifications.php
+
+**Files:**
+- Modify: `bin/notifications.php`
+
+This file has no unit tests today (it's an exec CLI). We rely on manual verification + the fact that Task 4 already added the `require_once registerChannels.php` line.
+
+- [ ] **Step 1: Replace the validation list (3 occurrences)**
+
+Open `bin/notifications.php`. Find all three occurrences of:
+```php
+if (! in_array($type, ['ntfy', 'pushover'], true)) {
+```
+Replace each with:
+```php
+if (! \NwsCad\Notifications\ChannelRegistry::has($type)) {
+```
+And replace the corresponding error message:
+```php
+fwrite(STDERR, "Unknown channel type: {$type}. Available: " . implode(', ', \NwsCad\Notifications\ChannelRegistry::types()) . "\n");
+```
+
+- [ ] **Step 2: Replace the base-URL env var ternary**
+
+Find:
+```php
+$envKey = $type === 'ntfy' ? 'NTFY_BASE_URL' : 'PUSHOVER_BASE_URL';
+```
+
+Replace with:
+```php
+$envKey = \NwsCad\Notifications\ChannelRegistry::get($type)->baseUrlEnv;
+```
+
+- [ ] **Step 3: Replace the default-config ternary**
+
+Find:
+```php
+$defaultConfig = $type === 'ntfy'
+    ? ['auth_token_env' => 'NTFY_AUTH_TOKEN']
+    : ['token_env' => 'PUSHOVER_TOKEN', 'user_env' => 'PUSHOVER_USER'];
+```
+
+Replace with:
+```php
+$defaultConfig = \NwsCad\Notifications\ChannelRegistry::get($type)->defaultConfig;
+```
+
+- [ ] **Step 4: Update the help text generator**
+
+Locate the help/usage block at the top of the file (around lines 20–30 — `enable <type> ... ('ntfy'|'pushover')` etc.). Replace the static channel list in help text with a dynamic one generated from the registry. After the autoload + registerChannels include but before the help block, build a dynamic line:
+
+```php
+$availableTypes = implode('|', \NwsCad\Notifications\ChannelRegistry::types());
+```
+
+Then use `{$availableTypes}` in place of the literal `'ntfy'|'pushover'` strings in the help text.
+
+For the "environment variables" block (lines ~26–27 currently), iterate the registry:
+
+```php
+$envBlock = '';
+foreach (\NwsCad\Notifications\ChannelRegistry::all() as $d) {
+    $envBlock .= "  {$d->type}: " . implode(', ', $d->requiredEnvs) . "\n";
+}
+```
+
+And echo `$envBlock` in the help text where the static list was.
+
+- [ ] **Step 5: Manual verification**
+
+Run:
+```bash
+php bin/notifications.php list
+php bin/notifications.php enable badtype 2>&1 | grep "Available:"
+php bin/notifications.php
+```
+
+Expected:
+- `list` works unchanged.
+- `enable badtype` prints "Unknown channel type: badtype. Available: ntfy, pushover".
+- Help text shows the dynamic type list.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bin/notifications.php
+git commit -m "refactor(notifications): CLI dispatches type validation via registry"
+```
+
+---
+
+### Task 8: Remove unused NotificationChannel::type()
+
+The interface method has zero callers (verified by grep). With all consumers migrated to `descriptor()`, we drop the redundant method.
+
+**Files:**
+- Modify: `src/Notifications/NotificationChannel.php`
+- Modify: `src/Notifications/Channels/NtfyChannel.php` (remove `type()` impl)
+- Modify: `src/Notifications/Channels/PushoverChannel.php` (remove `type()` impl)
+
+- [ ] **Step 1: Verify zero callers (defensive check)**
+
+Run:
+```bash
+grep -rn '::type()' src/ tests/ bin/ | grep -v 'ChannelType\|ChannelRegistry\|->type\b\|\$d->type\|\$descriptor->type\|\.swp'
+```
+Expected: no matches.
+
+- [ ] **Step 2: Remove from the interface**
+
+In `src/Notifications/NotificationChannel.php`, delete the `public static function type(): string;` line. The interface should now read:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Notifications;
+
+interface NotificationChannel
+{
+    public static function descriptor(): ChannelDescriptor;
+
+    /**
+     * @return SendResult[]  One result per attempt that produced a permanent
+     *                       outcome (one per topic for ntfy, one per send
+     *                       for pushover/webhook).
+     */
+    public function send(IncidentDto $incident, NotificationContext $context): array;
+}
+```
+
+- [ ] **Step 3: Remove the concrete implementations**
+
+In both `NtfyChannel.php` and `PushoverChannel.php`, delete the `public static function type(): string { return '...'; }` method.
+
+- [ ] **Step 4: Run full unit suite**
+
+Run: `composer test:unit`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Notifications/NotificationChannel.php \
+        src/Notifications/Channels/NtfyChannel.php \
+        src/Notifications/Channels/PushoverChannel.php
+git commit -m "refactor(notifications): drop unused NotificationChannel::type()"
+```
+
+---
+
+### Task 9: HttpPost::postJson() method
+
+WebhookChannel needs a JSON-body POST. `HttpPost` currently only does form-fields POST. Add a sibling method.
+
+**Files:**
+- Modify: `src/Notifications/Channels/HttpPost.php`
+- Create: `tests/Unit/Notifications/Channels/HttpPostJsonTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Unit/Notifications/Channels/HttpPostJsonTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications\Channels;
+
+use NwsCad\Notifications\Channels\HttpPost;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(HttpPost::class)]
+final class HttpPostJsonTest extends TestCase
+{
+    public function testPostJsonHits200OnLocalServer(): void
+    {
+        $server = $this->startEchoServer();
+        try {
+            $http   = new HttpPost();
+            $result = $http->postJson(
+                url: "http://127.0.0.1:{$server['port']}/",
+                payload: ['intent' => 'Created', 'topics' => ['A', 'B']],
+                timeoutSec: 5,
+                headers: ['Authorization' => 'Bearer test-token'],
+            );
+
+            $this->assertSame(200, $result['status']);
+            $this->assertStringContainsString('Created', $result['body']);
+            $this->assertStringContainsString('Bearer test-token', $result['body']);
+            $this->assertStringContainsString('application/json', $result['body']);
+        } finally {
+            $this->stopEchoServer($server);
+        }
+    }
+
+    /**
+     * @return array{proc:resource,port:int,scriptPath:string}
+     */
+    private function startEchoServer(): array
+    {
+        $port = $this->findFreePort();
+        $script = tempnam(sys_get_temp_dir(), 'echo') . '.php';
+        file_put_contents($script, <<<'PHP'
+<?php
+$body = file_get_contents('php://input') ?: '';
+$ct   = $_SERVER['HTTP_CONTENT_TYPE'] ?? '';
+$auth = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+header('Content-Type: text/plain');
+echo "body=$body|ct=$ct|auth=$auth";
+PHP);
+        $cmd = sprintf('php -S 127.0.0.1:%d %s', $port, escapeshellarg($script));
+        $proc = proc_open($cmd, [
+            0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w'],
+        ], $pipes);
+        if (! is_resource($proc)) {
+            $this->fail('failed to start local echo server');
+        }
+        // Wait up to 3s for the port to be listening.
+        $deadline = microtime(true) + 3.0;
+        while (microtime(true) < $deadline) {
+            $sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.2);
+            if ($sock !== false) { fclose($sock); break; }
+            usleep(50_000);
+        }
+        return ['proc' => $proc, 'port' => $port, 'scriptPath' => $script];
+    }
+
+    private function stopEchoServer(array $server): void
+    {
+        if (isset($server['proc']) && is_resource($server['proc'])) {
+            proc_terminate($server['proc']);
+            proc_close($server['proc']);
+        }
+        if (isset($server['scriptPath']) && file_exists($server['scriptPath'])) {
+            @unlink($server['scriptPath']);
+        }
+    }
+
+    private function findFreePort(): int
+    {
+        $sock = socket_create_listen(0);
+        if ($sock === false) { $this->fail('socket_create_listen failed'); }
+        socket_getsockname($sock, $addr, $port);
+        socket_close($sock);
+        return (int) $port;
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/Channels/HttpPostJsonTest.php`
+Expected: FAIL with `Call to undefined method ... postJson()`.
+
+- [ ] **Step 3: Add postJson() to HttpPost**
+
+In `src/Notifications/Channels/HttpPost.php`, add this method below the existing `post()`:
+
+```php
+/**
+ * POST a JSON-encoded body and return the status + body.
+ *
+ * @param array<mixed>          $payload Encoded with JSON_THROW_ON_ERROR.
+ * @param array<string,string>  $headers Additional headers (Content-Type is added automatically).
+ *
+ * @return array{status:int, body:string}
+ */
+public function postJson(string $url, array $payload, int $timeoutSec, array $headers = []): array
+{
+    $ch = curl_init();
+    if ($ch === false) {
+        return ['status' => 0, 'body' => 'curl_init failed'];
+    }
+
+    $body = json_encode($payload, JSON_THROW_ON_ERROR);
+
+    $headerLines = ['Content-Type: application/json'];
+    foreach ($headers as $k => $v) {
+        // Skip an explicit Content-Type so we don't emit two.
+        if (strcasecmp($k, 'Content-Type') === 0) {
+            $headerLines[0] = "Content-Type: {$v}";
+            continue;
+        }
+        $headerLines[] = "{$k}: {$v}";
+    }
+
+    curl_setopt_array($ch, [
+        CURLOPT_URL            => $url,
+        CURLOPT_POST           => true,
+        CURLOPT_POSTFIELDS     => $body,
+        CURLOPT_HTTPHEADER     => $headerLines,
+        CURLOPT_TIMEOUT        => $timeoutSec,
+        CURLOPT_CONNECTTIMEOUT => min(10, $timeoutSec),
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_SSL_VERIFYPEER => true,
+        CURLOPT_SSL_VERIFYHOST => 2,
+        CURLOPT_FAILONERROR    => false,
+    ]);
+
+    $responseBody = curl_exec($ch);
+    $status       = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    $error        = curl_error($ch);
+    curl_close($ch);
+
+    if ($responseBody === false) {
+        return ['status' => $status, 'body' => "curl error: {$error}"];
+    }
+
+    return ['status' => $status, 'body' => (string) $responseBody];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/Channels/HttpPostJsonTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Notifications/Channels/HttpPost.php tests/Unit/Notifications/Channels/HttpPostJsonTest.php
+git commit -m "feat(notifications): HttpPost::postJson() for JSON-body POST"
+```
+
+---
+
+### Task 10: WebhookChannel — substitution logic + unit tests
+
+**Files:**
+- Create: `src/Notifications/Channels/WebhookChannel.php`
+- Create: `tests/Unit/Notifications/Channels/WebhookChannelTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Unit/Notifications/Channels/WebhookChannelTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications\Channels;
+
+use DateTimeImmutable;
+use NwsCad\Notifications\Channels\WebhookChannel;
+use NwsCad\Notifications\Events\Intent;
+use NwsCad\Notifications\IncidentDto;
+use NwsCad\Notifications\NotificationContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(WebhookChannel::class)]
+final class WebhookChannelTest extends TestCase
+{
+    private function dto(): IncidentDto
+    {
+        return new IncidentDto(
+            dbCallId: 1,
+            callId: 42,
+            callNumber: 'CN-100',
+            callType: 'STRUCT FIRE',
+            agencyType: 'FIRE',
+            jurisdiction: 'CityA|CityB',
+            units: 'E1|L2',
+            commonName: null,
+            fullAddress: '123 Main St',
+            nearestCrossStreets: null,
+            policeBeat: null,
+            fireQuadrant: null,
+            natureOfCall: null,
+            narrative: 'large flames visible',
+            alarmLevel: 2,
+            createDateTime: '2026-05-12T10:00:00Z',
+            latitude: null,
+            longitude: null,
+        );
+    }
+
+    private function context(): NotificationContext
+    {
+        return new NotificationContext(
+            intent: Intent::Created,
+            resendAll: true,
+            topicsToNotify: ['FIRE', 'E1', 'L2'],
+            channelConfig: [],
+        );
+    }
+
+    public function testStringPlaceholderSubstitution(): void
+    {
+        $payload = WebhookChannel::buildPayload(
+            template: ['text' => '{intent}: {call_type} at {full_address}'],
+            dto: $this->dto(),
+            context: $this->context(),
+        );
+        $this->assertSame(
+            '{"text":"Created: STRUCT FIRE at 123 Main St"}',
+            $payload,
+        );
+    }
+
+    public function testRawArrayPlaceholderSubstitution(): void
+    {
+        $payload = WebhookChannel::buildPayload(
+            template: ['topics' => '${topics}'],
+            dto: $this->dto(),
+            context: $this->context(),
+        );
+        $this->assertSame(
+            '{"topics":["FIRE","E1","L2"]}',
+            $payload,
+        );
+    }
+
+    public function testUnknownPlaceholderPassesThrough(): void
+    {
+        $payload = WebhookChannel::buildPayload(
+            template: ['text' => 'hi {unknown_thing}'],
+            dto: $this->dto(),
+            context: $this->context(),
+        );
+        $this->assertStringContainsString('{unknown_thing}', $payload);
+    }
+
+    public function testRawUnitsAndJurisdictionSplit(): void
+    {
+        $payload = WebhookChannel::buildPayload(
+            template: ['u' => '${units}', 'j' => '${jurisdiction}'],
+            dto: $this->dto(),
+            context: $this->context(),
+        );
+        $decoded = json_decode($payload, true);
+        $this->assertSame(['E1', 'L2'], $decoded['u']);
+        $this->assertSame(['CityA', 'CityB'], $decoded['j']);
+    }
+
+    public function testMissingTemplateThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('webhook: template required');
+
+        new WebhookChannel(
+            baseUrl: 'https://example.test/hook',
+            config: ['template' => null],
+        );
+    }
+
+    public function testCrLfInAuthTokenRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CR/LF');
+
+        new WebhookChannel(
+            baseUrl: 'https://example.test/hook',
+            config: ['template' => ['text' => 'x']],
+            authToken: "ok\r\nInjected: header",
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/Channels/WebhookChannelTest.php`
+Expected: FAIL — class missing.
+
+- [ ] **Step 3: Implement WebhookChannel**
+
+Create `src/Notifications/Channels/WebhookChannel.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Notifications\Channels;
+
+use InvalidArgumentException;
+use NwsCad\Config;
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\IncidentDto;
+use NwsCad\Notifications\NotificationChannel;
+use NwsCad\Notifications\NotificationContext;
+use NwsCad\Notifications\SendResult;
+
+final class WebhookChannel implements NotificationChannel
+{
+    private const DEFAULT_TIMEOUT_SEC = 10;
+    private const RETRY_DELAYS_SEC    = [1, 3, 9];
+
+    /** @var array<mixed> */
+    private readonly array $template;
+    private readonly ?string $authHeader;
+    private readonly ?string $authToken;
+    private readonly int $timeoutSec;
+    private readonly HttpPost $http;
+
+    /**
+     * @param array<string,mixed> $config
+     */
+    public function __construct(
+        public readonly string $baseUrl,
+        array $config,
+        ?string $authToken = null,
+        ?HttpPost $http = null,
+    ) {
+        $template = $config['template'] ?? null;
+        if (! is_array($template) || $template === []) {
+            throw new InvalidArgumentException('webhook: template required');
+        }
+        $this->template = $template;
+
+        $this->authHeader = isset($config['auth_header']) ? (string) $config['auth_header'] : null;
+
+        if ($authToken !== null && preg_match('/[\r\n]/', $authToken) === 1) {
+            throw new InvalidArgumentException('webhook: auth token contains CR/LF');
+        }
+        $this->authToken = $authToken;
+
+        $this->timeoutSec = isset($config['timeout_sec']) ? max(1, (int) $config['timeout_sec']) : self::DEFAULT_TIMEOUT_SEC;
+        $this->http       = $http ?? new HttpPost();
+    }
+
+    public static function descriptor(): ChannelDescriptor
+    {
+        return new ChannelDescriptor(
+            type:          'webhook',
+            label:         'Generic webhook',
+            baseUrlEnv:    'WEBHOOK_BASE_URL',
+            requiredEnvs:  [],   // varies by config; template-driven
+            defaultConfig: [
+                'template'    => ['text' => '{intent}: {call_type} at {full_address}', 'topics' => '${topics}'],
+                'timeout_sec' => self::DEFAULT_TIMEOUT_SEC,
+            ],
+            factory: static function (array $row, Config $cfg): NotificationChannel {
+                $raw    = $row['config_json'] ?? '';
+                $config = $raw !== '' ? (json_decode($raw, true) ?: []) : [];
+                $token  = null;
+                if (! empty($config['auth_token_env'])) {
+                    $token = $cfg->secret((string) $config['auth_token_env']);
+                }
+                return new self(
+                    baseUrl: (string) $row['base_url'],
+                    config:  $config,
+                    authToken: $token,
+                );
+            },
+        );
+    }
+
+    /**
+     * @return SendResult[]
+     */
+    public function send(IncidentDto $incident, NotificationContext $context): array
+    {
+        $body = self::buildPayload($this->template, $incident, $context);
+
+        // buildPayload's output is canonical JSON; decode for postJson.
+        $payload = json_decode($body, true);
+        if ($payload === null) {
+            return [SendResult::fail(
+                httpStatus: 0,
+                durationMs: 0,
+                error: 'webhook: substituted template is not valid JSON',
+            )];
+        }
+
+        $headers = [];
+        if ($this->authHeader !== null && $this->authToken !== null) {
+            $headers[$this->authHeader] = $this->authToken;
+        }
+
+        $lastStatus = 0;
+        $lastError  = null;
+        $startedAt  = microtime(true);
+
+        foreach ([0, ...self::RETRY_DELAYS_SEC] as $delay) {
+            if ($delay > 0) {
+                sleep($delay);
+            }
+
+            $attemptStart = microtime(true);
+            $result       = $this->http->postJson($this->baseUrl, $payload, $this->timeoutSec, $headers);
+            $lastStatus   = $result['status'];
+            $lastError    = $result['body'];
+            $durationMs   = (int) ((microtime(true) - $attemptStart) * 1000);
+
+            if ($lastStatus >= 200 && $lastStatus < 300) {
+                return [SendResult::ok(httpStatus: $lastStatus, durationMs: $durationMs)];
+            }
+            if ($lastStatus >= 400 && $lastStatus < 500) {
+                break;   // permanent
+            }
+            // 5xx and 0 (network) → retry
+        }
+
+        return [SendResult::fail(
+            httpStatus: $lastStatus,
+            durationMs: (int) ((microtime(true) - $startedAt) * 1000),
+            error: $lastError ?? 'unknown',
+        )];
+    }
+
+    /**
+     * Two-pass template substitution. Public + static for unit-testing without
+     * needing to construct a full WebhookChannel.
+     *
+     * @param array<mixed> $template
+     */
+    public static function buildPayload(array $template, IncidentDto $dto, NotificationContext $context): string
+    {
+        $strVars = [
+            '{intent}'          => $context->intent->value,
+            '{call_id}'         => (string) $dto->callId,
+            '{call_number}'     => $dto->callNumber,
+            '{call_type}'       => (string) ($dto->callType ?? ''),
+            '{full_address}'    => (string) ($dto->fullAddress ?? ''),
+            '{create_datetime}' => $dto->createDateTime,
+            '{alarm_level}'     => (string) $dto->alarmLevel,
+            '{narrative}'       => (string) ($dto->narrative ?? ''),
+            '{agency_type}'     => (string) ($dto->agencyType ?? ''),
+            '{jurisdiction}'    => (string) ($dto->jurisdiction ?? ''),
+            '{units}'           => $dto->units,
+            '{topics}'          => implode(', ', $context->topicsToNotify),
+        ];
+
+        $walked = self::walk($template, $strVars);
+        $json   = json_encode($walked, JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            throw new \RuntimeException('webhook: failed to encode template');
+        }
+
+        $rawVars = [
+            '"${topics}"'       => json_encode($context->topicsToNotify, JSON_UNESCAPED_SLASHES),
+            '"${units}"'        => json_encode(self::splitPipe($dto->units), JSON_UNESCAPED_SLASHES),
+            '"${jurisdiction}"' => json_encode(self::splitPipe($dto->jurisdiction ?? ''), JSON_UNESCAPED_SLASHES),
+        ];
+        return strtr($json, $rawVars);
+    }
+
+    /**
+     * @param array<mixed> $node
+     * @param array<string,string> $vars
+     * @return array<mixed>
+     */
+    private static function walk(array $node, array $vars): array
+    {
+        $out = [];
+        foreach ($node as $k => $v) {
+            if (is_array($v)) {
+                $out[$k] = self::walk($v, $vars);
+            } elseif (is_string($v)) {
+                $out[$k] = strtr($v, $vars);
+            } else {
+                $out[$k] = $v;
+            }
+        }
+        return $out;
+    }
+
+    /** @return string[] */
+    private static function splitPipe(string $value): array
+    {
+        if ($value === '') {
+            return [];
+        }
+        return array_values(array_filter(
+            array_map('trim', explode('|', $value)),
+            static fn (string $v): bool => $v !== '',
+        ));
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/Channels/WebhookChannelTest.php`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Notifications/Channels/WebhookChannel.php tests/Unit/Notifications/Channels/WebhookChannelTest.php
+git commit -m "feat(notifications): WebhookChannel with templated JSON payloads"
+```
+
+---
+
+### Task 11: Register WebhookChannel + update boot test
+
+**Files:**
+- Modify: `src/Notifications/registerChannels.php`
+- Modify: `tests/Unit/Notifications/RegisterChannelsBootTest.php`
+
+- [ ] **Step 1: Update the boot test to expect `webhook`**
+
+In `tests/Unit/Notifications/RegisterChannelsBootTest.php`, change the assertion:
+
+```php
+$this->assertEqualsCanonicalizing(
+    ['ntfy', 'pushover', 'webhook'],
+    ChannelRegistry::types(),
+);
+```
+
+Also add `#[UsesClass(\NwsCad\Notifications\Channels\WebhookChannel::class)]` to the class-level attributes.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/RegisterChannelsBootTest.php`
+Expected: FAIL (registry only contains ntfy + pushover).
+
+- [ ] **Step 3: Register WebhookChannel in the boot file**
+
+In `src/Notifications/registerChannels.php`, add the use-statement and register call:
+
+```php
+use NwsCad\Notifications\Channels\WebhookChannel;
+
+// (after the two existing register() calls)
+ChannelRegistry::register(WebhookChannel::descriptor());
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/Unit/Notifications/RegisterChannelsBootTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Notifications/registerChannels.php tests/Unit/Notifications/RegisterChannelsBootTest.php
+git commit -m "feat(notifications): register WebhookChannel at boot"
+```
+
+---
+
+### Task 12: Webhook end-to-end integration test
+
+**Files:**
+- Create: `tests/Integration/Notifications/WebhookEndToEndTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Integration/Notifications/WebhookEndToEndTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Notifications;
+
+use DateTimeImmutable;
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\ChannelFactory;
+use NwsCad\Notifications\ChannelRegistry;
+use NwsCad\Notifications\Channels\WebhookChannel;
+use NwsCad\Notifications\Events\CallProcessedEvent;
+use NwsCad\Notifications\Events\Intent;
+use NwsCad\Notifications\IncidentDto;
+use NwsCad\Notifications\NotificationDispatcher;
+use NwsCad\Notifications\SendResult;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+#[UsesClass(WebhookChannel::class)]
+#[UsesClass(ChannelRegistry::class)]
+#[UsesClass(ChannelDescriptor::class)]
+#[UsesClass(ChannelFactory::class)]
+#[UsesClass(NotificationDispatcher::class)]
+#[UsesClass(IncidentDto::class)]
+#[UsesClass(SendResult::class)]
+final class WebhookEndToEndTest extends TestCase
+{
+    public function testDispatcherDeliversToWebhookOnce(): void
+    {
+        ChannelRegistry::clear();
+        ChannelRegistry::register(WebhookChannel::descriptor());
+
+        $server = $this->startCaptureServer();
+        try {
+            $row = [
+                'id'          => 1,
+                'name'        => 'test',
+                'type'        => 'webhook',
+                'enabled'     => 1,
+                'base_url'    => "http://127.0.0.1:{$server['port']}/",
+                'config_json' => json_encode([
+                    'template' => [
+                        'intent'  => '{intent}',
+                        'address' => '{full_address}',
+                        'topics'  => '${topics}',
+                    ],
+                ]),
+                'last_error'  => null,
+            ];
+
+            $repo = $this->channelRepoWithRows([$row]);
+            $factory = new ChannelFactory(\NwsCad\Config::getInstance());
+
+            $dispatcher = new NotificationDispatcher(
+                channelRepo: $repo,
+                incidentLoader: fn (int $id): IncidentDto => new IncidentDto(
+                    dbCallId: $id, callId: $id, callNumber: 'CN-1',
+                    callType: 'EMS', agencyType: 'EMS', jurisdiction: 'CityA',
+                    units: 'M1', commonName: null, fullAddress: '5 Oak Lane',
+                    nearestCrossStreets: null, policeBeat: null,
+                    fireQuadrant: null, natureOfCall: null, narrative: '',
+                    alarmLevel: 1, createDateTime: '2026-05-12T11:00:00Z',
+                    latitude: null, longitude: null,
+                ),
+                channelFactory: fn (array $r) => $factory->create($r),
+                deltaSeconds: 9999,
+            );
+
+            $event = new CallProcessedEvent(
+                dbCallId: 1, intent: Intent::Created,
+                createDateTime: new DateTimeImmutable(),
+                changedFields: [], addedTopics: [],
+            );
+            $dispatcher->handle($event);
+
+            $captured = $this->readCapture($server['capturePath']);
+            $this->assertCount(1, $captured, 'webhook should be POSTed exactly once');
+            $decoded = json_decode($captured[0], true);
+            $this->assertSame('Created', $decoded['intent']);
+            $this->assertSame('5 Oak Lane', $decoded['address']);
+            $this->assertSame(['EMS', 'CityA', 'M1'], $decoded['topics']);
+        } finally {
+            $this->stopCaptureServer($server);
+            ChannelRegistry::clear();
+        }
+    }
+
+    // Implement startCaptureServer / stopCaptureServer / channelRepoWithRows /
+    // readCapture helpers. The capture server writes each POST body to a
+    // tempfile, one line per request (similar pattern to HttpPostJsonTest's
+    // echo server but writing to disk instead of stdout).
+
+    private function startCaptureServer(): array
+    {
+        $port        = $this->findFreePort();
+        $capturePath = tempnam(sys_get_temp_dir(), 'capture');
+        $script      = tempnam(sys_get_temp_dir(), 'cap_php') . '.php';
+        file_put_contents($script, "<?php\nfile_put_contents("
+            . var_export($capturePath, true)
+            . ", file_get_contents('php://input') . \"\\n\", FILE_APPEND);\n"
+            . "header('Content-Type: text/plain'); echo 'OK';\n");
+
+        $proc = proc_open(
+            sprintf('php -S 127.0.0.1:%d %s', $port, escapeshellarg($script)),
+            [0 => ['pipe','r'], 1 => ['pipe','w'], 2 => ['pipe','w']],
+            $pipes,
+        );
+
+        $deadline = microtime(true) + 3.0;
+        while (microtime(true) < $deadline) {
+            $sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.2);
+            if ($sock !== false) { fclose($sock); break; }
+            usleep(50_000);
+        }
+        return ['proc' => $proc, 'port' => $port, 'capturePath' => $capturePath, 'scriptPath' => $script];
+    }
+
+    private function stopCaptureServer(array $s): void
+    {
+        if (is_resource($s['proc'] ?? null)) {
+            proc_terminate($s['proc']);
+            proc_close($s['proc']);
+        }
+        foreach (['capturePath', 'scriptPath'] as $k) {
+            if (! empty($s[$k]) && file_exists($s[$k])) {
+                @unlink($s[$k]);
+            }
+        }
+    }
+
+    /** @return string[] */
+    private function readCapture(string $path): array
+    {
+        $raw = @file_get_contents($path) ?: '';
+        return array_values(array_filter(explode("\n", $raw)));
+    }
+
+    private function findFreePort(): int
+    {
+        $sock = socket_create_listen(0);
+        socket_getsockname($sock, $addr, $port);
+        socket_close($sock);
+        return (int) $port;
+    }
+
+    private function channelRepoWithRows(array $rows): \NwsCad\Notifications\ChannelRepositoryInterface
+    {
+        return new class($rows) implements \NwsCad\Notifications\ChannelRepositoryInterface {
+            public function __construct(private array $rows) {}
+            public function listEnabled(): array { return $this->rows; }
+            public function recordSend(int $channelId, ?int $callId, ?string $intent, SendResult $result): void {}
+            public function markFailure(int $channelId, string $message): void {}
+        };
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Integration/Notifications/WebhookEndToEndTest.php`
+Expected: FAIL until WebhookChannel + registry are wired (they are after Task 11, so this should pass after Task 11). If it fails for harness reasons (e.g., `ChannelRepositoryInterface` signature mismatch), align the anonymous-class methods with the real interface.
+
+- [ ] **Step 3: Verify the test passes**
+
+Run: `./vendor/bin/phpunit tests/Integration/Notifications/WebhookEndToEndTest.php`
+Expected: PASS — exactly one POST captured with the expected substituted body.
+
+- [ ] **Step 4: Run the full integration suite**
+
+Run: `composer test:integration`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/Integration/Notifications/WebhookEndToEndTest.php
+git commit -m "test(notifications): webhook end-to-end via local capture server"
+```
+
+---
+
+### Task 13: Documentation and changelog
+
+**Files:**
+- Modify: `docs/NOTIFICATIONS.md`
+- Modify: `CHANGELOG.md`
+- Modify: `.env.example` (add `WEBHOOK_BASE_URL` reference under the security/notifications section)
+
+- [ ] **Step 1: Add "Webhook channel" section to docs/NOTIFICATIONS.md**
+
+Open `docs/NOTIFICATIONS.md` and add a new section after the Pushover section. Cover:
+
+1. **What it is** — one HTTP POST per CallProcessedEvent with a JSON payload built from a template stored in `notification_channels.config_json`.
+2. **Enable it** — sample CLI and API commands:
+   ```bash
+   php bin/notifications.php enable webhook --base-url=https://hooks.slack.com/services/T.../B.../...
+   ```
+3. **Template syntax** — list of `{string}` placeholders and `${array}` placeholders (copy from spec section 2).
+4. **Slack example** — full `config_json.template` for Slack incoming webhook.
+5. **Discord example** — Discord-shaped template.
+6. **Authentication** — `auth_header` + `auth_token_env` pattern.
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Under a new `## [Unreleased]` section (or whichever section is current per the project convention), add:
+
+```markdown
+### Added
+- `ChannelRegistry` and `ChannelDescriptor` for plug-in channel registration.
+- `WebhookChannel` — generic HTTP POST channel with JSON-template payload
+  configuration (covers Slack, Discord, Mattermost, Home Assistant by config).
+- `HttpPost::postJson()` helper for JSON-body HTTP POST.
+
+### Changed
+- `ChannelFactory::create()` now dispatches via `ChannelRegistry` instead of
+  a hardcoded `match` on channel type.
+- `NotificationsController` and `bin/notifications.php` query the registry
+  for validation, help text, and default config_json.
+
+### Removed
+- Unused `NotificationChannel::type()` interface method (descriptor() replaces it).
+```
+
+- [ ] **Step 3: Optional .env.example mention**
+
+Under the Security/Notifications block of `.env.example`, add a note:
+
+```
+# Webhook channels (enable via `bin/notifications.php enable webhook ...`)
+# Each webhook channel's auth uses notification_channels.config_json:
+#   auth_header / auth_token_env. No global env var required.
+```
+
+- [ ] **Step 4: Sanity-check all tests still pass**
+
+Run: `composer test`
+Expected: all suites green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/NOTIFICATIONS.md CHANGELOG.md .env.example
+git commit -m "docs(notifications): document ChannelRegistry and WebhookChannel"
+```
+
+---
+
+## Final code-quality review
+
+After Task 13 commits, dispatch a final code-review subagent for the whole branch (spec compliance + code quality across all 13 commits) before opening the PR. Then follow the `superpowers:finishing-a-development-branch` flow.
+
+## Spec coverage check
+
+| Spec requirement | Task(s) |
+|---|---|
+| `ChannelDescriptor` value object | 1 |
+| `ChannelRegistry` static container | 2 |
+| `descriptor()` static on every channel | 3, 10 |
+| `registerChannels.php` includes wired into watcher/HTTP/CLI | 4 |
+| `ChannelFactory::create()` registry-driven | 5 |
+| `NotificationsController` registry-driven | 6 |
+| `bin/notifications.php` registry-driven | 7 |
+| `NotificationChannel::type()` removed | 8 |
+| `HttpPost::postJson()` | 9 |
+| `WebhookChannel` with two-pass template substitution | 10 |
+| `WebhookChannel` registered at boot | 11 |
+| End-to-end integration test | 12 |
+| Docs + changelog | 13 |
+| `tests/Support/RegistryTestCase.php` test-base for clear() in tearDown | Spec mentioned; each test in tasks above includes its own setUp/tearDown clear(). The base class is optional and can be added in a follow-up if the duplication becomes painful. |

--- a/docs/superpowers/plans/2026-05-12-channel-registry.md
+++ b/docs/superpowers/plans/2026-05-12-channel-registry.md
@@ -36,7 +36,7 @@ Create `tests/Unit/Notifications/ChannelDescriptorTest.php`:
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Notifications;
+namespace NwsCad\Tests\Unit\Notifications;
 
 use Closure;
 use NwsCad\Notifications\ChannelDescriptor;
@@ -158,7 +158,7 @@ Create `tests/Unit/Notifications/ChannelRegistryTest.php`:
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Notifications;
+namespace NwsCad\Tests\Unit\Notifications;
 
 use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\ChannelRegistry;
@@ -327,7 +327,7 @@ Create `tests/Unit/Notifications/Channels/NtfyChannelDescriptorTest.php`:
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Notifications\Channels;
+namespace NwsCad\Tests\Unit\Notifications\Channels;
 
 use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\Channels\NtfyChannel;
@@ -360,7 +360,7 @@ Create `tests/Unit/Notifications/Channels/PushoverChannelDescriptorTest.php`:
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Notifications\Channels;
+namespace NwsCad\Tests\Unit\Notifications\Channels;
 
 use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\Channels\PushoverChannel;
@@ -484,7 +484,7 @@ Create `tests/Unit/Notifications/RegisterChannelsBootTest.php`:
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Notifications;
+namespace NwsCad\Tests\Unit\Notifications;
 
 use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\ChannelRegistry;
@@ -609,7 +609,7 @@ If it exists, read it to learn how the factory is tested. If it doesn't exist, c
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Notifications;
+namespace NwsCad\Tests\Unit\Notifications;
 
 use InvalidArgumentException;
 use NwsCad\Config;
@@ -990,7 +990,7 @@ Create `tests/Unit/Notifications/Channels/HttpPostJsonTest.php`:
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Notifications\Channels;
+namespace NwsCad\Tests\Unit\Notifications\Channels;
 
 use NwsCad\Notifications\Channels\HttpPost;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -1166,7 +1166,7 @@ Create `tests/Unit/Notifications/Channels/WebhookChannelTest.php`:
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Notifications\Channels;
+namespace NwsCad\Tests\Unit\Notifications\Channels;
 
 use DateTimeImmutable;
 use NwsCad\Notifications\Channels\WebhookChannel;
@@ -1576,7 +1576,7 @@ Create `tests/Integration/Notifications/WebhookEndToEndTest.php`:
 
 declare(strict_types=1);
 
-namespace Tests\Integration\Notifications;
+namespace NwsCad\Tests\Integration\Notifications;
 
 use DateTimeImmutable;
 use NwsCad\Notifications\ChannelDescriptor;

--- a/docs/superpowers/specs/2026-05-12-channel-registry-design.md
+++ b/docs/superpowers/specs/2026-05-12-channel-registry-design.md
@@ -1,0 +1,331 @@
+# ChannelRegistry & WebhookChannel Design
+
+**Date:** 2026-05-12
+**Status:** Design draft (awaiting review)
+**Origin:** Codebase audit, original ask "spec out a means of adding/modifying new transport channels."
+
+## Goal
+
+Localize all per-channel-type knowledge into a single class per channel, so adding a new transport (Slack, Discord, Mattermost, custom webhook) is one new file + one bootstrap line — not edits to `ChannelFactory`, `NotificationsController`, `bin/notifications.php`, and their tests.
+
+Ship one new channel — `WebhookChannel` — as a real consumer of the new abstraction, covering Slack/Discord/Mattermost/Home-Assistant via JSON-template config rather than per-platform PHP classes.
+
+## Current coupling
+
+The string `'ntfy'` and/or `'pushover'` appears in at least these places today:
+
+| Site | Coupling |
+|---|---|
+| `src/Notifications/ChannelFactory.php` | Hardcoded `match` on type with per-channel constructor arguments |
+| `src/Api/Controllers/NotificationsController.php` | `validateType()` hardcoded allowlist; `enable()` default-config branch |
+| `bin/notifications.php` | Validation list (3 sites), base-URL env var ternary, default-config ternary |
+| Tests for the above | Mock the same hardcoded set |
+
+Adding a third channel today means touching 5+ files. The `NotificationChannel::type()` static method already exists but isn't used for dispatch — `ChannelFactory` has its own hardcoded map.
+
+## Architecture
+
+A static `ChannelRegistry` holds one `ChannelDescriptor` per type. Every coupling site queries the registry instead of hardcoding the list. The DB schema is unchanged — `notification_channels.type` stays a free-string, and the registry is the runtime allowlist.
+
+```
+ChannelRegistry  ──registers──>  ChannelDescriptor (type, label, defaults, factory closure)
+       │
+       ├── used by  →  ChannelFactory::create($row)              // replaces the hardcoded match
+       ├── used by  →  NotificationsController::validateType()
+       └── used by  →  bin/notifications.php (help, validation, defaults)
+```
+
+`NotificationDispatcher` is unchanged — it never knew about types; it just calls `ChannelFactory::create($row)`.
+
+## Components
+
+### `src/Notifications/ChannelDescriptor.php` (new, `final` value object)
+
+```php
+final class ChannelDescriptor
+{
+    public function __construct(
+        public readonly string $type,           // 'ntfy', 'pushover', 'webhook'
+        public readonly string $label,          // human-readable
+        public readonly string $baseUrlEnv,     // CLI/API default-base-url env var name
+        public readonly array  $requiredEnvs,   // env vars checked at enable time
+        public readonly array  $defaultConfig,  // becomes config_json on first enable
+        /** @var \Closure(array,Config): NotificationChannel */
+        public readonly \Closure $factory,
+    ) {}
+}
+```
+
+### `src/Notifications/ChannelRegistry.php` (new, static container)
+
+```php
+final class ChannelRegistry
+{
+    /** @var array<string, ChannelDescriptor> */
+    private static array $by_type = [];
+
+    public static function register(ChannelDescriptor $d): void { self::$by_type[$d->type] = $d; }
+    public static function get(string $type): ?ChannelDescriptor { return self::$by_type[$type] ?? null; }
+    public static function has(string $type): bool { return isset(self::$by_type[$type]); }
+    public static function types(): array { return array_keys(self::$by_type); }
+    public static function all(): array { return self::$by_type; }
+    public static function clear(): void { self::$by_type = []; }  // tests only
+}
+```
+
+### `src/Notifications/NotificationChannel.php` (interface change)
+
+The interface gains `descriptor()` and drops the unused `type()`:
+
+```php
+interface NotificationChannel
+{
+    public static function descriptor(): ChannelDescriptor;   // NEW (replaces type())
+    public function send(IncidentDto $incident, NotificationContext $context): array;
+}
+```
+
+`NotificationChannel::type()` has zero callers in the codebase — it was a contract method nothing relied on. Removing it eliminates a redundancy (the type is in the descriptor) and is safe. `NtfyChannel`, `PushoverChannel`, and the new `WebhookChannel` implement `descriptor()`. Example for `NtfyChannel`:
+
+```php
+public static function descriptor(): ChannelDescriptor
+{
+    return new ChannelDescriptor(
+        type:          'ntfy',
+        label:         'ntfy.sh',
+        baseUrlEnv:    'NTFY_BASE_URL',
+        requiredEnvs:  ['NTFY_AUTH_TOKEN'],
+        defaultConfig: ['auth_token_env' => 'NTFY_AUTH_TOKEN'],
+        factory: function (array $row, Config $cfg): NotificationChannel {
+            $config = json_decode($row['config_json'] !== '' ? $row['config_json'] : '{}', true) ?: [];
+            return new self(
+                baseUrl:   $row['base_url'],
+                authToken: $cfg->secret($config['auth_token_env'] ?? 'NTFY_AUTH_TOKEN'),
+                config:    $config,
+            );
+        },
+    );
+}
+```
+
+### `src/Notifications/registerChannels.php` (new, single source of truth)
+
+```php
+<?php
+declare(strict_types=1);
+
+use NwsCad\Notifications\ChannelRegistry;
+use NwsCad\Notifications\Channels\NtfyChannel;
+use NwsCad\Notifications\Channels\PushoverChannel;
+use NwsCad\Notifications\Channels\WebhookChannel;
+
+ChannelRegistry::clear();   // idempotent — safe to include multiple times
+ChannelRegistry::register(NtfyChannel::descriptor());
+ChannelRegistry::register(PushoverChannel::descriptor());
+ChannelRegistry::register(WebhookChannel::descriptor());
+```
+
+Included from `src/watcher.php` (watcher process) and `src/bootstrap.php` (HTTP process).
+
+### `src/Notifications/ChannelFactory.php` (refactor)
+
+```php
+public function create(array $row): NotificationChannel
+{
+    $d = ChannelRegistry::get($row['type'])
+        ?? throw new InvalidArgumentException("Unknown channel type: {$row['type']}");
+    return ($d->factory)($row, $this->config);
+}
+```
+
+### `src/Notifications/Channels/WebhookChannel.php` (new)
+
+Generic HTTP POST channel. `config_json` shape:
+
+```json
+{
+  "template": { "text": "{intent}: {call_type} at {full_address}", "topics": "${topics}" },
+  "auth_header":   "Authorization",
+  "auth_token_env": "WEBHOOK_AUTH_TOKEN",
+  "timeout_sec":   10
+}
+```
+
+Sends one HTTP POST per `CallProcessedEvent` (regardless of topic count). Returns a single `SendResult`.
+
+#### Template substitution
+
+Two-pass:
+
+1. **String substitution** — walk the template; for every string leaf, replace `{placeholder}` occurrences with stringified values. Unknown placeholders pass through literally.
+2. **Raw substitution** — after JSON-encoding, post-replace `"${name}"` (with the surrounding quotes) with the raw JSON value (e.g. `"${topics}"` → `["A","B","C"]`).
+
+Authoring rule: raw placeholders must appear as quoted string values in the template so the template remains valid JSON during authoring.
+
+**Available `{string}` placeholders:**
+`{intent}`, `{call_id}`, `{call_number}`, `{call_type}`, `{call_type_description}`, `{full_address}`, `{create_datetime}`, `{alarm_level}`, `{narrative}`, `{agency_type}`, `{jurisdiction}`, `{units}`, `{topics}` (comma-joined).
+
+**Available `${array}` raw placeholders:**
+`${topics}`, `${units}`, `${jurisdiction}`.
+
+#### Slack example template
+
+```json
+{
+  "text": ":rotating_light: *{call_type}* at {full_address}",
+  "attachments": [
+    { "fields": [
+        {"title": "Intent",  "value": "{intent}",        "short": true},
+        {"title": "Topics",  "value": "{topics}",        "short": true},
+        {"title": "Units",   "value": "{units}",         "short": false}
+    ]}
+  ]
+}
+```
+
+#### Auth handling
+
+If `auth_header` and `auth_token_env` are both set in `config_json`, the channel reads the secret via `Config::secret($auth_token_env)` and adds `$auth_header: <value>` to the request headers. Secrets are registered with `SecretRegistry` so `RedactingProcessor` scrubs them from logs. CR/LF in token values is rejected at channel construction (same guard as `NtfyChannel`).
+
+#### Retry semantics
+
+Identical to ntfy/pushover: 3 attempts with 1s/3s/9s backoff. 4xx is permanent (no retry). 5xx and network failures retry. Configurable per-row via `config_json.timeout_sec` (default 10).
+
+### `src/Notifications/Channels/HttpPost.php` (new method)
+
+```php
+public function postJson(string $url, array $payload, int $timeoutSec, array $headers = []): array
+```
+
+Adds a JSON-body sibling to the existing form-fields `post()`. Returns `['status' => int, 'body' => string]`. The existing `post()` is unchanged (used by `PushoverChannel`).
+
+## Data flow
+
+### Boot (HTTP request)
+
+```
+public/index.php / public/api.php
+   require __DIR__ . '/../src/bootstrap.php'
+        Config::getInstance()
+        require __DIR__ . '/Notifications/registerChannels.php'
+        SecurityHeaders::setAll(...)
+        CorsPolicy::apply(...)
+        TrustedProxy::guard(...)
+        $GLOBALS['__identity'] = Identity::extract(...)
+```
+
+### Boot (watcher)
+
+```
+src/watcher.php
+   Config::getInstance()
+   require __DIR__ . '/Notifications/registerChannels.php'
+   EventDispatcher::subscribe(NotificationDispatcher::handle(...))
+   FileWatcher::start()
+```
+
+### Event delivery (unchanged behaviour — the whole point)
+
+```
+AegisXmlParser commits
+   └─> EventDispatcher.dispatch(CallProcessedEvent)
+        └─> NotificationDispatcher.handle()
+             └─> for each row in channelRepo.listEnabled():
+                  └─> ChannelFactory.create(row)
+                       └─> ChannelRegistry.get(row.type).factory(row, config)
+                  └─> channel.send(dto, context)  // → SendResult[]
+                  └─> channelRepo.recordSend(...)
+```
+
+### CLI: `php bin/notifications.php enable webhook --base-url=https://hooks.slack.com/...`
+
+```
+1. parse args
+2. d = ChannelRegistry::get('webhook')  → ChannelDescriptor or null (→ "Unknown type" error showing available)
+3. base_url = --base-url ?? getenv(d.baseUrlEnv) ?? error
+4. UrlValidator::validateChannelBaseUrl(base_url, ...)
+5. for each env in d.requiredEnvs: fail if not set
+6. INSERT notification_channels (name, type, enabled=1, base_url, config_json=JSON(d.defaultConfig))
+```
+
+### API: `POST /api/notifications/{type}/enable`
+
+`NotificationsController::validateType($type)` becomes `ChannelRegistry::has($type)`. The hardcoded `defaultConfig` branch in `enable()` becomes `$descriptor->defaultConfig` lookup. Identity recording and URL validation are unchanged.
+
+## Error handling
+
+| Scenario | Behaviour |
+|---|---|
+| DB row with unknown `type` | `ChannelRegistry::get()` returns null, factory throws `InvalidArgumentException("Unknown channel type: X")`; `NotificationDispatcher` catches Throwable, marks row failed with the message |
+| Closure-based factory throws (e.g. `MissingSecretException`) | Caught by existing try/catch in `NotificationDispatcher::handle()`; row marked failed |
+| `WebhookChannel` `config_json` missing `template` | Factory throws `InvalidArgumentException('webhook: template required')`; row marked failed |
+| `WebhookChannel` template contains `{unknown}` | Pass-through: placeholder stays literal in the payload. Operator sees it in the receiver. |
+| `WebhookChannel` raw substitution finds `${unknown}` | Pass-through: stays literal. |
+| `WebhookChannel` HTTP failure | Existing retry semantics; final result returned via `SendResult` |
+| CLI: `enable badtype` | STDERR: `Unknown channel type: badtype. Available: ntfy, pushover, webhook` |
+| API: `POST /api/notifications/badtype/enable` | 400 with `errors.available_types: [...]` in response body |
+| Bootstrap order: registry queried before populated | Tests register channels in `setUp()`; production paths always call after `registerChannels.php`. Unit test guards: `RegisterChannelsBootTest` asserts include populates ≥1 descriptor. |
+
+## Testing
+
+### New unit tests
+
+- `tests/Unit/Notifications/ChannelRegistryTest.php` — register/get/has/types/all/clear round-trip; duplicate-type overwrite
+- `tests/Unit/Notifications/ChannelDescriptorTest.php` — immutability; closure invocation produces `NotificationChannel`
+- `tests/Unit/Notifications/RegisterChannelsBootTest.php` — include `registerChannels.php`, assert `types()` returns exactly `['ntfy','pushover','webhook']`
+- `tests/Unit/Notifications/Channels/WebhookChannelTest.php` — `{placeholder}` substitution, `${array}` substitution, unknown placeholder passes through, missing template throws, auth header injected
+- `tests/Unit/Notifications/Channels/WebhookChannelHttpTest.php` — `HttpPost::postJson` mocked; 5xx retries (3), 4xx terminal, network failure retries, success returns one `SendResult`
+
+### Refactored existing tests
+
+- `tests/Unit/Notifications/ChannelFactoryTest.php` — uses `ChannelRegistry::register(NtfyChannel::descriptor())` in setUp, `clear()` in tearDown
+- `tests/Integration/NotificationsApiTest.php` — adds `testEnableWebhookSucceeds`, `testEnableUnknownTypeReturnsAvailable`, `testEnableWebhookRequiresTemplate`
+
+### New integration test
+
+- `tests/Integration/Notifications/WebhookEndToEndTest.php` — spins a local PHP HTTP server on `127.0.0.1:0` via `proc_open`, enables a webhook channel pointing at it, dispatches a synthetic `CallProcessedEvent`, asserts one POST with the expected substituted body and `topics` JSON array
+
+### Test-isolation convention
+
+Every test that registers channels MUST call `ChannelRegistry::clear()` in `tearDown()`. Convention encoded in a `tests/Support/RegistryTestCase.php` base class; documented in `docs/TESTING.md`.
+
+### Coverage tags
+
+New classes get `@covers <Class>`. Test classes need `@uses` for the transitive set — `\NwsCad\Notifications\ChannelRegistry`, `\NwsCad\Notifications\ChannelDescriptor`, plus the standard `Database`, `Config`, `Response`, `Logger`, `Logging\RedactingProcessor`, `Logging\SecretRegistry`.
+
+## Rollout
+
+Zero data migration. Schema unchanged. Existing `ntfy`/`pushover` rows continue to work as soon as the registry is populated at boot.
+
+### TDD-ordered tasks (implementation plan will expand each)
+
+1. `ChannelDescriptor` value object + tests
+2. `ChannelRegistry` static container + tests
+3. `NotificationChannel` interface: add `descriptor()`, drop unused `type()`
+4. `descriptor()` on `NtfyChannel` and `PushoverChannel` + tests
+5. `src/Notifications/registerChannels.php` + boot test
+6. `ChannelFactory::create()` refactored to use registry
+7. `registerChannels.php` wired into `src/watcher.php` and `src/bootstrap.php`
+8. `NotificationsController::validateType()` + `enable()` defaults refactored to use registry
+9. `bin/notifications.php` (validation, help text, env defaults) refactored to use registry
+10. `HttpPost::postJson($url, $payload, $timeout, $headers)` method + tests
+11. `WebhookChannel` (descriptor, send, template substitution) + unit tests
+12. `WebhookChannel` registered in `registerChannels.php`
+13. Webhook end-to-end integration test
+14. Docs: `docs/NOTIFICATIONS.md` (webhook + template syntax + Slack/Discord examples), `CHANGELOG.md`
+
+Steps 3/4/6 land in the same commit (interface change forces all implementers to gain `descriptor()` together).
+
+## Out of scope
+
+- Async outbox / worker (separate audit item)
+- Per-channel rate limiting
+- Channel quotas / spend caps
+- UI for adding/editing channels
+- SMTP / non-HTTP transports
+
+## Risk register
+
+- **Static registry state leaks across tests** — mitigated by `RegistryTestCase::tearDown()` and explicit `clear()` discipline
+- **`config_json.template` is operator-authored JSON** — bad JSON breaks delivery for that one channel only; we surface the error via `markFailure` so it lands in `last_error`
+- **Webhook template placeholders pass through literally on typos** — accepted tradeoff for production resilience; operator sees the literal in the receiver

--- a/docs/superpowers/specs/2026-05-12-channel-registry-design.md
+++ b/docs/superpowers/specs/2026-05-12-channel-registry-design.md
@@ -163,7 +163,7 @@ Two-pass:
 Authoring rule: raw placeholders must appear as quoted string values in the template so the template remains valid JSON during authoring.
 
 **Available `{string}` placeholders:**
-`{intent}`, `{call_id}`, `{call_number}`, `{call_type}`, `{call_type_description}`, `{full_address}`, `{create_datetime}`, `{alarm_level}`, `{narrative}`, `{agency_type}`, `{jurisdiction}`, `{units}`, `{topics}` (comma-joined).
+`{intent}`, `{call_id}`, `{call_number}`, `{call_type}`, `{full_address}`, `{create_datetime}`, `{alarm_level}`, `{narrative}`, `{agency_type}`, `{jurisdiction}`, `{units}`, `{topics}` (comma-joined).
 
 **Available `${array}` raw placeholders:**
 `${topics}`, `${units}`, `${jurisdiction}`.

--- a/src/Api/Controllers/NotificationsController.php
+++ b/src/Api/Controllers/NotificationsController.php
@@ -8,6 +8,7 @@ use NwsCad\Api\Response;
 use NwsCad\Config;
 use NwsCad\Database;
 use NwsCad\Notifications\ChannelFactory;
+use NwsCad\Notifications\ChannelRegistry;
 use NwsCad\Notifications\ChannelRepository;
 use NwsCad\Notifications\IncidentDto;
 use NwsCad\Notifications\Events\Intent;
@@ -99,7 +100,9 @@ final class NotificationsController
     {
         try {
             if (! $this->validateType($type)) {
-                Response::error("Unknown channel type: {$type}", 404);
+                Response::error("Unknown channel type: {$type}", 400, [
+                    'available_types' => ChannelRegistry::types(),
+                ]);
                 return;
             }
 
@@ -129,9 +132,8 @@ final class NotificationsController
                     Response::error("Missing env var: {$envKey}", 422);
                     return;
                 }
-                $defaultConfig = $type === 'ntfy'
-                    ? '{"auth_token_env":"NTFY_AUTH_TOKEN","alarm_priority_map":{"1":3,"2":4,"3":5}}'
-                    : '{"token_env":"PUSHOVER_TOKEN","user_env":"PUSHOVER_USER"}';
+                $descriptor    = ChannelRegistry::get($type);
+                $defaultConfig = json_encode($descriptor->defaultConfig);
 
                 $ins = $this->db->prepare(
                     "INSERT INTO notification_channels (name, type, enabled, base_url, config_json, last_updated_actor)
@@ -165,7 +167,9 @@ final class NotificationsController
     {
         try {
             if (! $this->validateType($type)) {
-                Response::error("Unknown channel type: {$type}", 404);
+                Response::error("Unknown channel type: {$type}", 400, [
+                    'available_types' => ChannelRegistry::types(),
+                ]);
                 return;
             }
             $actor = \NwsCad\Security\Identity::current()->user;
@@ -186,7 +190,9 @@ final class NotificationsController
     {
         try {
             if (! $this->validateType($type)) {
-                Response::error("Unknown channel type: {$type}", 404);
+                Response::error("Unknown channel type: {$type}", 400, [
+                    'available_types' => ChannelRegistry::types(),
+                ]);
                 return;
             }
 
@@ -300,7 +306,9 @@ final class NotificationsController
     {
         try {
             if (! $this->validateType($type)) {
-                Response::error("Unknown channel type: {$type}", 404);
+                Response::error("Unknown channel type: {$type}", 400, [
+                    'available_types' => ChannelRegistry::types(),
+                ]);
                 return;
             }
             $actor = \NwsCad\Security\Identity::current()->user;
@@ -343,7 +351,7 @@ final class NotificationsController
 
     private function validateType(string $type): bool
     {
-        return in_array($type, ['ntfy', 'pushover'], true);
+        return ChannelRegistry::has($type);
     }
 
     private function resolveChannelId(string $channel): ?int

--- a/src/Notifications/ChannelDescriptor.php
+++ b/src/Notifications/ChannelDescriptor.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Notifications;
+
+use Closure;
+
+/**
+ * Immutable registration record for a notification channel type.
+ *
+ * Each channel class exposes a static `descriptor()` returning one of these;
+ * `registerChannels.php` registers them all at boot, and ChannelRegistry holds
+ * them for the rest of the request/process lifetime.
+ */
+final class ChannelDescriptor
+{
+    /**
+     * @param string[]            $requiredEnvs Env-var names that must be present when the channel is enabled.
+     * @param array<string,mixed> $defaultConfig Becomes notification_channels.config_json on first enable.
+     * @param Closure(array<string,mixed>, \NwsCad\Config): NotificationChannel $factory
+     *        Builds an instance of the channel from a DB row and the current Config.
+     */
+    public function __construct(
+        public readonly string  $type,
+        public readonly string  $label,
+        public readonly string  $baseUrlEnv,
+        public readonly array   $requiredEnvs,
+        public readonly array   $defaultConfig,
+        public readonly Closure $factory,
+    ) {
+    }
+}

--- a/src/Notifications/ChannelFactory.php
+++ b/src/Notifications/ChannelFactory.php
@@ -7,7 +7,7 @@ namespace NwsCad\Notifications;
 use InvalidArgumentException;
 use NwsCad\Config;
 
-final class ChannelFactory
+class ChannelFactory
 {
     public function __construct(private readonly Config $config)
     {

--- a/src/Notifications/ChannelFactory.php
+++ b/src/Notifications/ChannelFactory.php
@@ -6,8 +6,6 @@ namespace NwsCad\Notifications;
 
 use InvalidArgumentException;
 use NwsCad\Config;
-use NwsCad\Notifications\Channels\NtfyChannel;
-use NwsCad\Notifications\Channels\PushoverChannel;
 
 class ChannelFactory
 {
@@ -20,21 +18,10 @@ class ChannelFactory
      */
     public function create(array $row): NotificationChannel
     {
-        $cfg = json_decode($row['config_json'] !== '' ? $row['config_json'] : '{}', true) ?: [];
+        $type = $row['type'] ?? '';
+        $d = ChannelRegistry::get($type)
+            ?? throw new InvalidArgumentException("Unknown channel type: {$type}");
 
-        return match ($row['type']) {
-            'ntfy' => new NtfyChannel(
-                baseUrl: $row['base_url'],
-                authToken: $this->config->secret($cfg['auth_token_env'] ?? 'NTFY_AUTH_TOKEN'),
-                config: $cfg,
-            ),
-            'pushover' => new PushoverChannel(
-                baseUrl: $row['base_url'],
-                token: $this->config->secret($cfg['token_env'] ?? 'PUSHOVER_TOKEN'),
-                user: $this->config->secret($cfg['user_env'] ?? 'PUSHOVER_USER'),
-                config: $cfg,
-            ),
-            default => throw new InvalidArgumentException("Unknown channel type: {$row['type']}"),
-        };
+        return ($d->factory)($row, $this->config);
     }
 }

--- a/src/Notifications/ChannelFactory.php
+++ b/src/Notifications/ChannelFactory.php
@@ -7,7 +7,7 @@ namespace NwsCad\Notifications;
 use InvalidArgumentException;
 use NwsCad\Config;
 
-class ChannelFactory
+final class ChannelFactory
 {
     public function __construct(private readonly Config $config)
     {

--- a/src/Notifications/ChannelRegistry.php
+++ b/src/Notifications/ChannelRegistry.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Notifications;
+
+/**
+ * Static registry of channel descriptors. Populated by registerChannels.php
+ * at boot of every entry point (watcher, HTTP, CLI). Queried by
+ * ChannelFactory at dispatch time and by the API/CLI for validation and help.
+ *
+ * Static state is intentional given PHP's per-request lifecycle; tests MUST
+ * call `clear()` in tearDown to prevent state leak between tests.
+ */
+final class ChannelRegistry
+{
+    /** @var array<string, ChannelDescriptor> */
+    private static array $byType = [];
+
+    public static function register(ChannelDescriptor $d): void
+    {
+        self::$byType[$d->type] = $d;
+    }
+
+    public static function get(string $type): ?ChannelDescriptor
+    {
+        return self::$byType[$type] ?? null;
+    }
+
+    public static function has(string $type): bool
+    {
+        return isset(self::$byType[$type]);
+    }
+
+    /** @return string[] */
+    public static function types(): array
+    {
+        return array_keys(self::$byType);
+    }
+
+    /** @return array<string, ChannelDescriptor> */
+    public static function all(): array
+    {
+        return self::$byType;
+    }
+
+    public static function clear(): void
+    {
+        self::$byType = [];
+    }
+}

--- a/src/Notifications/Channels/HttpPost.php
+++ b/src/Notifications/Channels/HttpPost.php
@@ -37,4 +37,56 @@ class HttpPost
         }
         return ['status' => $status, 'body' => (string) $body];
     }
+
+    /**
+     * POST a JSON-encoded body and return the status + body.
+     *
+     * @param array<mixed>          $payload Encoded with JSON_THROW_ON_ERROR.
+     * @param array<string,string>  $headers Additional headers (Content-Type is added automatically; user-supplied Content-Type overrides).
+     *
+     * @return array{status:int, body:string}
+     */
+    public function postJson(string $url, array $payload, int $timeoutSec, array $headers = []): array
+    {
+        $ch = curl_init();
+        if ($ch === false) {
+            return ['status' => 0, 'body' => 'curl_init failed'];
+        }
+
+        $body = json_encode($payload, JSON_THROW_ON_ERROR);
+
+        $headerLines = ['Content-Type: application/json'];
+        foreach ($headers as $k => $v) {
+            // Allow user-supplied Content-Type to override the default.
+            if (strcasecmp($k, 'Content-Type') === 0) {
+                $headerLines[0] = "Content-Type: {$v}";
+                continue;
+            }
+            $headerLines[] = "{$k}: {$v}";
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_URL            => $url,
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => $body,
+            CURLOPT_HTTPHEADER     => $headerLines,
+            CURLOPT_TIMEOUT        => $timeoutSec,
+            CURLOPT_CONNECTTIMEOUT => min(10, $timeoutSec),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
+            CURLOPT_FAILONERROR    => false,
+        ]);
+
+        $responseBody = curl_exec($ch);
+        $status       = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        $error        = curl_error($ch);
+        curl_close($ch);
+
+        if ($responseBody === false) {
+            return ['status' => $status, 'body' => "curl error: {$error}"];
+        }
+
+        return ['status' => $status, 'body' => (string) $responseBody];
+    }
 }

--- a/src/Notifications/Channels/NtfyChannel.php
+++ b/src/Notifications/Channels/NtfyChannel.php
@@ -53,7 +53,10 @@ final class NtfyChannel implements NotificationChannel
             label:         'ntfy.sh',
             baseUrlEnv:    'NTFY_BASE_URL',
             requiredEnvs:  ['NTFY_AUTH_TOKEN'],
-            defaultConfig: ['auth_token_env' => 'NTFY_AUTH_TOKEN'],
+            defaultConfig: [
+                'auth_token_env'     => 'NTFY_AUTH_TOKEN',
+                'alarm_priority_map' => ['1' => 3, '2' => 4, '3' => 5],
+            ],
             factory: static function (array $row, Config $cfg): NotificationChannel {
                 $raw    = $row['config_json'] ?? '';
                 $config = $raw !== '' ? (json_decode($raw, true) ?: []) : [];

--- a/src/Notifications/Channels/NtfyChannel.php
+++ b/src/Notifications/Channels/NtfyChannel.php
@@ -41,11 +41,6 @@ final class NtfyChannel implements NotificationChannel
         }
     }
 
-    public static function type(): string
-    {
-        return 'ntfy';
-    }
-
     public static function descriptor(): ChannelDescriptor
     {
         return new ChannelDescriptor(

--- a/src/Notifications/Channels/NtfyChannel.php
+++ b/src/Notifications/Channels/NtfyChannel.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace NwsCad\Notifications\Channels;
 
+use NwsCad\Config;
 use NwsCad\Logger;
+use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\IncidentDto;
 use NwsCad\Notifications\NotificationChannel;
 use NwsCad\Notifications\NotificationContext;
@@ -42,6 +44,26 @@ final class NtfyChannel implements NotificationChannel
     public static function type(): string
     {
         return 'ntfy';
+    }
+
+    public static function descriptor(): ChannelDescriptor
+    {
+        return new ChannelDescriptor(
+            type:          'ntfy',
+            label:         'ntfy.sh',
+            baseUrlEnv:    'NTFY_BASE_URL',
+            requiredEnvs:  ['NTFY_AUTH_TOKEN'],
+            defaultConfig: ['auth_token_env' => 'NTFY_AUTH_TOKEN'],
+            factory: static function (array $row, Config $cfg): NotificationChannel {
+                $raw    = $row['config_json'] ?? '';
+                $config = $raw !== '' ? (json_decode($raw, true) ?: []) : [];
+                return new self(
+                    baseUrl:   (string) $row['base_url'],
+                    authToken: $cfg->secret($config['auth_token_env'] ?? 'NTFY_AUTH_TOKEN'),
+                    config:    $config,
+                );
+            },
+        );
     }
 
     public function send(IncidentDto $incident, NotificationContext $context): array

--- a/src/Notifications/Channels/PushoverChannel.php
+++ b/src/Notifications/Channels/PushoverChannel.php
@@ -31,11 +31,6 @@ final class PushoverChannel implements NotificationChannel
         }
     }
 
-    public static function type(): string
-    {
-        return 'pushover';
-    }
-
     public static function descriptor(): ChannelDescriptor
     {
         return new ChannelDescriptor(

--- a/src/Notifications/Channels/PushoverChannel.php
+++ b/src/Notifications/Channels/PushoverChannel.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace NwsCad\Notifications\Channels;
 
+use NwsCad\Config;
 use NwsCad\Logger;
+use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\IncidentDto;
 use NwsCad\Notifications\NotificationChannel;
 use NwsCad\Notifications\NotificationContext;
@@ -32,6 +34,27 @@ final class PushoverChannel implements NotificationChannel
     public static function type(): string
     {
         return 'pushover';
+    }
+
+    public static function descriptor(): ChannelDescriptor
+    {
+        return new ChannelDescriptor(
+            type:          'pushover',
+            label:         'Pushover',
+            baseUrlEnv:    'PUSHOVER_BASE_URL',
+            requiredEnvs:  ['PUSHOVER_TOKEN', 'PUSHOVER_USER'],
+            defaultConfig: ['token_env' => 'PUSHOVER_TOKEN', 'user_env' => 'PUSHOVER_USER'],
+            factory: static function (array $row, Config $cfg): NotificationChannel {
+                $raw    = $row['config_json'] ?? '';
+                $config = $raw !== '' ? (json_decode($raw, true) ?: []) : [];
+                return new self(
+                    baseUrl: (string) $row['base_url'],
+                    token:   $cfg->secret($config['token_env'] ?? 'PUSHOVER_TOKEN'),
+                    user:    $cfg->secret($config['user_env']  ?? 'PUSHOVER_USER'),
+                    config:  $config,
+                );
+            },
+        );
     }
 
     public function send(IncidentDto $incident, NotificationContext $context): array

--- a/src/Notifications/Channels/WebhookChannel.php
+++ b/src/Notifications/Channels/WebhookChannel.php
@@ -6,6 +6,7 @@ namespace NwsCad\Notifications\Channels;
 
 use InvalidArgumentException;
 use NwsCad\Config;
+use NwsCad\Logger;
 use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\IncidentDto;
 use NwsCad\Notifications\NotificationChannel;
@@ -87,6 +88,9 @@ final class WebhookChannel implements NotificationChannel
         // buildPayload's output is canonical JSON; decode for postJson.
         $payload = json_decode($body, true);
         if ($payload === null) {
+            Logger::getInstance()->error('Webhook channel: substituted template is not valid JSON', [
+                'baseUrl' => $this->baseUrl,
+            ]);
             return [SendResult::fail(
                 httpStatus: 0,
                 durationMs: 0,
@@ -118,10 +122,20 @@ final class WebhookChannel implements NotificationChannel
                 return [SendResult::ok(httpStatus: $lastStatus, durationMs: $durationMs)];
             }
             if ($lastStatus >= 400 && $lastStatus < 500) {
+                Logger::getInstance()->warning('Webhook channel: permanent failure', [
+                    'baseUrl'    => $this->baseUrl,
+                    'httpStatus' => $lastStatus,
+                ]);
                 break;   // permanent
             }
             // 5xx and 0 (network) → retry
         }
+
+        Logger::getInstance()->error('Webhook channel: send failed after retries', [
+            'baseUrl'    => $this->baseUrl,
+            'httpStatus' => $lastStatus,
+            'attempts'   => count(self::RETRY_DELAYS_SEC) + 1,
+        ]);
 
         return [SendResult::fail(
             httpStatus: $lastStatus,

--- a/src/Notifications/Channels/WebhookChannel.php
+++ b/src/Notifications/Channels/WebhookChannel.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Notifications\Channels;
+
+use InvalidArgumentException;
+use NwsCad\Config;
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\IncidentDto;
+use NwsCad\Notifications\NotificationChannel;
+use NwsCad\Notifications\NotificationContext;
+use NwsCad\Notifications\SendResult;
+
+final class WebhookChannel implements NotificationChannel
+{
+    private const DEFAULT_TIMEOUT_SEC = 10;
+    private const RETRY_DELAYS_SEC    = [1, 3, 9];
+
+    /** @var array<mixed> */
+    private readonly array $template;
+    private readonly ?string $authHeader;
+    private readonly ?string $authToken;
+    private readonly int $timeoutSec;
+    private readonly HttpPost $http;
+
+    /**
+     * @param array<string,mixed> $config
+     */
+    public function __construct(
+        public readonly string $baseUrl,
+        array $config,
+        ?string $authToken = null,
+        ?HttpPost $http = null,
+    ) {
+        $template = $config['template'] ?? null;
+        if (! is_array($template) || $template === []) {
+            throw new InvalidArgumentException('webhook: template required');
+        }
+        $this->template = $template;
+
+        $this->authHeader = isset($config['auth_header']) ? (string) $config['auth_header'] : null;
+
+        if ($authToken !== null && preg_match('/[\r\n]/', $authToken) === 1) {
+            throw new InvalidArgumentException('webhook: auth token contains CR/LF');
+        }
+        $this->authToken = $authToken;
+
+        $this->timeoutSec = isset($config['timeout_sec']) ? max(1, (int) $config['timeout_sec']) : self::DEFAULT_TIMEOUT_SEC;
+        $this->http       = $http ?? new HttpPost();
+    }
+
+    public static function descriptor(): ChannelDescriptor
+    {
+        return new ChannelDescriptor(
+            type:          'webhook',
+            label:         'Generic webhook',
+            baseUrlEnv:    'WEBHOOK_BASE_URL',
+            requiredEnvs:  [],   // varies by config; template-driven
+            defaultConfig: [
+                'template'    => ['text' => '{intent}: {call_type} at {full_address}', 'topics' => '${topics}'],
+                'timeout_sec' => self::DEFAULT_TIMEOUT_SEC,
+            ],
+            factory: static function (array $row, Config $cfg): NotificationChannel {
+                $raw    = $row['config_json'] ?? '';
+                $config = $raw !== '' ? (json_decode($raw, true) ?: []) : [];
+                $token  = null;
+                if (! empty($config['auth_token_env'])) {
+                    $token = $cfg->secret((string) $config['auth_token_env']);
+                }
+                return new self(
+                    baseUrl: (string) $row['base_url'],
+                    config:  $config,
+                    authToken: $token,
+                );
+            },
+        );
+    }
+
+    /**
+     * @return SendResult[]
+     */
+    public function send(IncidentDto $incident, NotificationContext $context): array
+    {
+        $body = self::buildPayload($this->template, $incident, $context);
+
+        // buildPayload's output is canonical JSON; decode for postJson.
+        $payload = json_decode($body, true);
+        if ($payload === null) {
+            return [SendResult::fail(
+                httpStatus: 0,
+                durationMs: 0,
+                error: 'webhook: substituted template is not valid JSON',
+            )];
+        }
+
+        $headers = [];
+        if ($this->authHeader !== null && $this->authToken !== null) {
+            $headers[$this->authHeader] = $this->authToken;
+        }
+
+        $lastStatus = 0;
+        $lastError  = null;
+        $startedAt  = microtime(true);
+
+        foreach ([0, ...self::RETRY_DELAYS_SEC] as $delay) {
+            if ($delay > 0) {
+                sleep($delay);
+            }
+
+            $attemptStart = microtime(true);
+            $result       = $this->http->postJson($this->baseUrl, $payload, $this->timeoutSec, $headers);
+            $lastStatus   = $result['status'];
+            $lastError    = $result['body'];
+            $durationMs   = (int) ((microtime(true) - $attemptStart) * 1000);
+
+            if ($lastStatus >= 200 && $lastStatus < 300) {
+                return [SendResult::ok(httpStatus: $lastStatus, durationMs: $durationMs)];
+            }
+            if ($lastStatus >= 400 && $lastStatus < 500) {
+                break;   // permanent
+            }
+            // 5xx and 0 (network) → retry
+        }
+
+        return [SendResult::fail(
+            httpStatus: $lastStatus,
+            durationMs: (int) ((microtime(true) - $startedAt) * 1000),
+            error: $lastError ?? 'unknown',
+        )];
+    }
+
+    /**
+     * Two-pass template substitution. Public + static for unit-testing without
+     * needing to construct a full WebhookChannel.
+     *
+     * @param array<mixed> $template
+     */
+    public static function buildPayload(array $template, IncidentDto $dto, NotificationContext $context): string
+    {
+        $strVars = [
+            '{intent}'          => $context->intent->value,
+            '{call_id}'         => (string) $dto->callId,
+            '{call_number}'     => $dto->callNumber,
+            '{call_type}'       => (string) ($dto->callType ?? ''),
+            '{full_address}'    => (string) ($dto->fullAddress ?? ''),
+            '{create_datetime}' => $dto->createDateTime,
+            '{alarm_level}'     => (string) $dto->alarmLevel,
+            '{narrative}'       => (string) ($dto->narrative ?? ''),
+            '{agency_type}'     => (string) ($dto->agencyType ?? ''),
+            '{jurisdiction}'    => (string) ($dto->jurisdiction ?? ''),
+            '{units}'           => $dto->units,
+            '{topics}'          => implode(', ', $context->topicsToNotify),
+        ];
+
+        $walked = self::walk($template, $strVars);
+        $json   = json_encode($walked, JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            throw new \RuntimeException('webhook: failed to encode template');
+        }
+
+        $rawVars = [
+            '"${topics}"'       => json_encode($context->topicsToNotify, JSON_UNESCAPED_SLASHES),
+            '"${units}"'        => json_encode(self::splitPipe($dto->units), JSON_UNESCAPED_SLASHES),
+            '"${jurisdiction}"' => json_encode(self::splitPipe($dto->jurisdiction ?? ''), JSON_UNESCAPED_SLASHES),
+        ];
+        return strtr($json, $rawVars);
+    }
+
+    /** Raw-array sentinels that must not be touched by the string-var pass. */
+    private const RAW_SENTINELS = ['${topics}', '${units}', '${jurisdiction}'];
+
+    /**
+     * @param array<mixed> $node
+     * @param array<string,string> $vars
+     * @return array<mixed>
+     */
+    private static function walk(array $node, array $vars): array
+    {
+        $out = [];
+        foreach ($node as $k => $v) {
+            if (is_array($v)) {
+                $out[$k] = self::walk($v, $vars);
+            } elseif (is_string($v) && ! in_array($v, self::RAW_SENTINELS, true)) {
+                $out[$k] = strtr($v, $vars);
+            } else {
+                $out[$k] = $v;
+            }
+        }
+        return $out;
+    }
+
+    /** @return string[] */
+    private static function splitPipe(string $value): array
+    {
+        if ($value === '') {
+            return [];
+        }
+        return array_values(array_filter(
+            array_map('trim', explode('|', $value)),
+            static fn (string $v): bool => $v !== '',
+        ));
+    }
+}

--- a/src/Notifications/NotificationChannel.php
+++ b/src/Notifications/NotificationChannel.php
@@ -6,14 +6,12 @@ namespace NwsCad\Notifications;
 
 interface NotificationChannel
 {
-    /**
-     * Channel type identifier matching notification_channels.type.
-     */
-    public static function type(): string;
+    public static function descriptor(): ChannelDescriptor;
 
     /**
      * @return SendResult[]  One result per attempt that produced a permanent
-     *                       outcome (one per topic for ntfy, one for pushover).
+     *                       outcome (one per topic for ntfy, one per send
+     *                       for pushover/webhook).
      */
     public function send(IncidentDto $incident, NotificationContext $context): array;
 }

--- a/src/Notifications/registerChannels.php
+++ b/src/Notifications/registerChannels.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use NwsCad\Notifications\ChannelRegistry;
+use NwsCad\Notifications\Channels\NtfyChannel;
+use NwsCad\Notifications\Channels\PushoverChannel;
+
+ChannelRegistry::clear();
+ChannelRegistry::register(NtfyChannel::descriptor());
+ChannelRegistry::register(PushoverChannel::descriptor());

--- a/src/Notifications/registerChannels.php
+++ b/src/Notifications/registerChannels.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use NwsCad\Notifications\ChannelRegistry;
 use NwsCad\Notifications\Channels\NtfyChannel;
 use NwsCad\Notifications\Channels\PushoverChannel;
+use NwsCad\Notifications\Channels\WebhookChannel;
 
 ChannelRegistry::clear();
 ChannelRegistry::register(NtfyChannel::descriptor());
 ChannelRegistry::register(PushoverChannel::descriptor());
+ChannelRegistry::register(WebhookChannel::descriptor());

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -12,6 +12,7 @@ use NwsCad\Security\TrustedProxy;
 
 (static function (): void {
     $config = Config::getInstance();
+    require_once __DIR__ . '/Notifications/registerChannels.php';
 
     $isHttps = ($_SERVER['HTTPS'] ?? '') === 'on'
         || ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '') === 'https';

--- a/src/watcher.php
+++ b/src/watcher.php
@@ -22,6 +22,7 @@ use NwsCad\Notifications\Events\CallProcessedEvent;
 // Initialize logger once
 $logger = Logger::getInstance();
 $config = Config::getInstance();
+require_once __DIR__ . '/Notifications/registerChannels.php';
 
 try {
     $logLevel = strtoupper($config->get('app.log_level', 'INFO'));

--- a/tests/Integration/Notifications/WebhookEndToEndTest.php
+++ b/tests/Integration/Notifications/WebhookEndToEndTest.php
@@ -28,6 +28,16 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(SendResult::class)]
 final class WebhookEndToEndTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        ChannelRegistry::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        ChannelRegistry::clear();
+    }
+
     public function testDispatcherDeliversToWebhookOnce(): void
     {
         ChannelRegistry::clear();

--- a/tests/Integration/Notifications/WebhookEndToEndTest.php
+++ b/tests/Integration/Notifications/WebhookEndToEndTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Integration\Notifications;
+
+use DateTimeImmutable;
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\ChannelFactory;
+use NwsCad\Notifications\ChannelRegistry;
+use NwsCad\Notifications\Channels\WebhookChannel;
+use NwsCad\Notifications\Events\CallProcessedEvent;
+use NwsCad\Notifications\Events\Intent;
+use NwsCad\Notifications\IncidentDto;
+use NwsCad\Notifications\NotificationDispatcher;
+use NwsCad\Notifications\SendResult;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+#[UsesClass(WebhookChannel::class)]
+#[UsesClass(ChannelRegistry::class)]
+#[UsesClass(ChannelDescriptor::class)]
+#[UsesClass(ChannelFactory::class)]
+#[UsesClass(NotificationDispatcher::class)]
+#[UsesClass(IncidentDto::class)]
+#[UsesClass(SendResult::class)]
+final class WebhookEndToEndTest extends TestCase
+{
+    public function testDispatcherDeliversToWebhookOnce(): void
+    {
+        ChannelRegistry::clear();
+        ChannelRegistry::register(WebhookChannel::descriptor());
+
+        $server = $this->startCaptureServer();
+        try {
+            $row = [
+                'id'          => 1,
+                'name'        => 'test',
+                'type'        => 'webhook',
+                'enabled'     => 1,
+                'base_url'    => "http://127.0.0.1:{$server['port']}/",
+                'config_json' => json_encode([
+                    'template' => [
+                        'intent'  => '{intent}',
+                        'address' => '{full_address}',
+                        'topics'  => '${topics}',
+                    ],
+                ]),
+                'last_error'  => null,
+            ];
+
+            $repo = $this->channelRepoWithRows([$row]);
+            $factory = new ChannelFactory(\NwsCad\Config::getInstance());
+
+            $dispatcher = new NotificationDispatcher(
+                channelRepo: $repo,
+                incidentLoader: fn (int $id): IncidentDto => IncidentDto::fromRow([
+                    'id'                   => $id,
+                    'call_id'              => (string) $id,
+                    'call_number'          => 'CN-1',
+                    'call_type'            => 'EMS',
+                    'agency_type'          => 'EMS',
+                    'jurisdiction'         => 'CityA',
+                    'units'                => 'M1',
+                    'common_name'          => null,
+                    'full_address'         => '5 Oak Lane',
+                    'nearest_cross_streets'=> null,
+                    'police_beat'          => null,
+                    'fire_quadrant'        => null,
+                    'nature_of_call'       => null,
+                    'narrative'            => '',
+                    'alarm_level'          => 1,
+                    'create_datetime'      => '2026-05-12T11:00:00Z',
+                    'latitude'             => null,
+                    'longitude'            => null,
+                ]),
+                channelFactory: fn (array $r) => $factory->create($r),
+                deltaSeconds: 9999,
+            );
+
+            $event = new CallProcessedEvent(
+                dbCallId: 1,
+                intent: Intent::Created,
+                changedFields: [],
+                createDateTime: new DateTimeImmutable(),
+                addedTopics: [],
+            );
+            $dispatcher->handle($event);
+
+            $captured = $this->readCapture($server['capturePath']);
+            $this->assertCount(1, $captured, 'webhook should be POSTed exactly once');
+            $decoded = json_decode($captured[0], true);
+            $this->assertSame('Created', $decoded['intent']);
+            $this->assertSame('5 Oak Lane', $decoded['address']);
+            $this->assertSame(['EMS', 'CityA', 'M1'], $decoded['topics']);
+        } finally {
+            $this->stopCaptureServer($server);
+            ChannelRegistry::clear();
+        }
+    }
+
+    private function startCaptureServer(): array
+    {
+        $port        = $this->findFreePort();
+        $capturePath = tempnam(sys_get_temp_dir(), 'capture');
+        $script      = tempnam(sys_get_temp_dir(), 'cap_php') . '.php';
+        file_put_contents($script, "<?php\nfile_put_contents("
+            . var_export($capturePath, true)
+            . ", file_get_contents('php://input') . \"\\n\", FILE_APPEND);\n"
+            . "header('Content-Type: text/plain'); echo 'OK';\n");
+
+        $proc = proc_open(
+            sprintf('php -S 127.0.0.1:%d %s', $port, escapeshellarg($script)),
+            [0 => ['pipe','r'], 1 => ['pipe','w'], 2 => ['pipe','w']],
+            $pipes,
+        );
+
+        $deadline = microtime(true) + 3.0;
+        while (microtime(true) < $deadline) {
+            $sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.2);
+            if ($sock !== false) { fclose($sock); break; }
+            usleep(50_000);
+        }
+        return ['proc' => $proc, 'port' => $port, 'capturePath' => $capturePath, 'scriptPath' => $script];
+    }
+
+    private function stopCaptureServer(array $s): void
+    {
+        if (is_resource($s['proc'] ?? null)) {
+            proc_terminate($s['proc']);
+            proc_close($s['proc']);
+        }
+        foreach (['capturePath', 'scriptPath'] as $k) {
+            if (! empty($s[$k]) && file_exists($s[$k])) {
+                @unlink($s[$k]);
+            }
+        }
+    }
+
+    /** @return string[] */
+    private function readCapture(string $path): array
+    {
+        $raw = @file_get_contents($path) ?: '';
+        return array_values(array_filter(explode("\n", $raw)));
+    }
+
+    private function findFreePort(): int
+    {
+        $sock = socket_create_listen(0);
+        socket_getsockname($sock, $addr, $port);
+        socket_close($sock);
+        return (int) $port;
+    }
+
+    private function channelRepoWithRows(array $rows): \NwsCad\Notifications\ChannelRepositoryInterface
+    {
+        return new class($rows) implements \NwsCad\Notifications\ChannelRepositoryInterface {
+            public function __construct(private array $rows) {}
+            public function listEnabled(): array { return $this->rows; }
+            public function recordSend(int $channelId, ?int $callId, ?string $intent, SendResult $result): void {}
+            public function markFailure(int $channelId, string $message): void {}
+        };
+    }
+}

--- a/tests/Integration/NotificationsApiTest.php
+++ b/tests/Integration/NotificationsApiTest.php
@@ -18,11 +18,15 @@ use PHPUnit\Framework\TestCase;
  * @uses \NwsCad\Logging\RedactingProcessor
  * @uses \NwsCad\Logging\SecretRegistry
  * @uses \NwsCad\Notifications\ChannelFactory
+ * @uses \NwsCad\Notifications\ChannelRegistry
+ * @uses \NwsCad\Notifications\ChannelDescriptor
  * @uses \NwsCad\Notifications\ChannelRepository
  * @uses \NwsCad\Notifications\IncidentDto
  * @uses \NwsCad\Notifications\NotificationContext
  * @uses \NwsCad\Notifications\SendResult
  * @uses \NwsCad\Notifications\Events\Intent
+ * @uses \NwsCad\Notifications\Channels\NtfyChannel
+ * @uses \NwsCad\Notifications\Channels\PushoverChannel
  * @uses \NwsCad\Security\UrlValidator
  * @uses \NwsCad\Security\Identity
  * @uses \NwsCad\Security\InputValidator
@@ -48,10 +52,17 @@ class NotificationsApiTest extends TestCase
         // testing mode short-circuits subsequent calls within a request, so
         // without a reset every test after the first would silently no-op.
         Response::resetForTesting();
+
+        // Populate the registry so validateType() works for ntfy/pushover.
+        // Tests that probe unknown types may clear/re-register as needed.
+        \NwsCad\Notifications\ChannelRegistry::clear();
+        \NwsCad\Notifications\ChannelRegistry::register(\NwsCad\Notifications\Channels\NtfyChannel::descriptor());
+        \NwsCad\Notifications\ChannelRegistry::register(\NwsCad\Notifications\Channels\PushoverChannel::descriptor());
     }
 
     protected function tearDown(): void
     {
+        \NwsCad\Notifications\ChannelRegistry::clear();
         unset($GLOBALS['__identity']);
         unset($_SERVER['HTTP_X_AUTH_USER']);
         parent::tearDown();
@@ -370,5 +381,22 @@ class NotificationsApiTest extends TestCase
             "SELECT last_updated_actor FROM notification_channels WHERE name = 'ntfy_primary'"
         )->fetch();
         $this->assertSame('k9barry', $row['last_updated_actor']);
+    }
+
+    public function testEnableUnknownTypeReturnsAvailableTypes(): void
+    {
+        // Registry already has ntfy + pushover from setUp(); just verify the
+        // error response includes the available_types list.
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $controller = new NotificationsController();
+        ob_start();
+        $controller->enable('badtype');
+        $body = (string) ob_get_clean();
+
+        $response = json_decode($body, true);
+        $this->assertSame(400, http_response_code());
+        $this->assertFalse($response['success']);
+        $this->assertSame(['ntfy', 'pushover'], $response['errors']['available_types']);
     }
 }

--- a/tests/Integration/NotificationsApiTest.php
+++ b/tests/Integration/NotificationsApiTest.php
@@ -254,7 +254,13 @@ class NotificationsApiTest extends TestCase
         $channelId = (int) self::$db->lastInsertId();
 
         $stub = new class implements \NwsCad\Notifications\NotificationChannel {
-            public static function type(): string { return 'ntfy'; }
+            public static function descriptor(): \NwsCad\Notifications\ChannelDescriptor {
+                return new \NwsCad\Notifications\ChannelDescriptor(
+                    type: 'stub', label: 'stub', baseUrlEnv: 'X',
+                    requiredEnvs: [], defaultConfig: [],
+                    factory: static fn (array $r, \NwsCad\Config $c) => throw new \LogicException('test stub'),
+                );
+            }
             public function send(\NwsCad\Notifications\IncidentDto $i, \NwsCad\Notifications\NotificationContext $c): array {
                 return [\NwsCad\Notifications\SendResult::ok(200, 12, 'test')];
             }
@@ -292,7 +298,13 @@ class NotificationsApiTest extends TestCase
             VALUES ('ntfy_primary', 'ntfy', 1, 'u', '{}')");
 
         $stub = new class implements \NwsCad\Notifications\NotificationChannel {
-            public static function type(): string { return 'ntfy'; }
+            public static function descriptor(): \NwsCad\Notifications\ChannelDescriptor {
+                return new \NwsCad\Notifications\ChannelDescriptor(
+                    type: 'stub', label: 'stub', baseUrlEnv: 'X',
+                    requiredEnvs: [], defaultConfig: [],
+                    factory: static fn (array $r, \NwsCad\Config $c) => throw new \LogicException('test stub'),
+                );
+            }
             public function send(\NwsCad\Notifications\IncidentDto $i, \NwsCad\Notifications\NotificationContext $c): array {
                 return [\NwsCad\Notifications\SendResult::fail(503, 9, 'Service Unavailable', 'test')];
             }

--- a/tests/Integration/Security/IdentityRoundtripTest.php
+++ b/tests/Integration/Security/IdentityRoundtripTest.php
@@ -15,15 +15,19 @@ use PHPUnit\Framework\TestCase;
  * @covers \NwsCad\Security\Identity
  * @uses \NwsCad\Api\Controllers\NotificationsController
  * @uses \NwsCad\Api\Response
- * @uses \NwsCad\Database
  * @uses \NwsCad\Config
+ * @uses \NwsCad\Database
  * @uses \NwsCad\Logger
  * @uses \NwsCad\Logging\RedactingProcessor
  * @uses \NwsCad\Logging\SecretRegistry
+ * @uses \NwsCad\Notifications\ChannelDescriptor
  * @uses \NwsCad\Notifications\ChannelFactory
+ * @uses \NwsCad\Notifications\ChannelRegistry
  * @uses \NwsCad\Notifications\ChannelRepository
- * @uses \NwsCad\Security\UrlValidator
+ * @uses \NwsCad\Notifications\Channels\NtfyChannel
+ * @uses \NwsCad\Notifications\Channels\PushoverChannel
  * @uses \NwsCad\Security\InputValidator
+ * @uses \NwsCad\Security\UrlValidator
  */
 class IdentityRoundtripTest extends TestCase
 {
@@ -44,6 +48,14 @@ class IdentityRoundtripTest extends TestCase
         Response::resetForTesting();
         unset($GLOBALS['__identity']);
         unset($_SERVER['HTTP_X_AUTH_USER']);
+        \NwsCad\Notifications\ChannelRegistry::clear();
+        \NwsCad\Notifications\ChannelRegistry::register(\NwsCad\Notifications\Channels\NtfyChannel::descriptor());
+        \NwsCad\Notifications\ChannelRegistry::register(\NwsCad\Notifications\Channels\PushoverChannel::descriptor());
+    }
+
+    protected function tearDown(): void
+    {
+        \NwsCad\Notifications\ChannelRegistry::clear();
     }
 
     public function testEnableRecordsExtractedIdentity(): void

--- a/tests/Unit/Notifications/ChannelDescriptorTest.php
+++ b/tests/Unit/Notifications/ChannelDescriptorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Notifications;
+namespace NwsCad\Tests\Unit\Notifications;
 
 use Closure;
 use NwsCad\Notifications\ChannelDescriptor;

--- a/tests/Unit/Notifications/ChannelDescriptorTest.php
+++ b/tests/Unit/Notifications/ChannelDescriptorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications;
+
+use Closure;
+use NwsCad\Notifications\ChannelDescriptor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ChannelDescriptor::class)]
+final class ChannelDescriptorTest extends TestCase
+{
+    public function testReadonlyPropertiesExposeConstructorArgs(): void
+    {
+        $factory = static fn (array $r, $cfg) => new \stdClass();
+
+        $d = new ChannelDescriptor(
+            type:          'demo',
+            label:         'Demo Channel',
+            baseUrlEnv:    'DEMO_BASE_URL',
+            requiredEnvs:  ['DEMO_TOKEN'],
+            defaultConfig: ['key' => 'value'],
+            factory:       $factory,
+        );
+
+        $this->assertSame('demo', $d->type);
+        $this->assertSame('Demo Channel', $d->label);
+        $this->assertSame('DEMO_BASE_URL', $d->baseUrlEnv);
+        $this->assertSame(['DEMO_TOKEN'], $d->requiredEnvs);
+        $this->assertSame(['key' => 'value'], $d->defaultConfig);
+        $this->assertInstanceOf(Closure::class, $d->factory);
+    }
+
+    public function testFactoryClosureIsInvokable(): void
+    {
+        $marker = new \stdClass();
+        $factory = static fn (array $row, $cfg): object => $marker;
+
+        $d = new ChannelDescriptor(
+            type: 't', label: 'l', baseUrlEnv: 'E',
+            requiredEnvs: [], defaultConfig: [],
+            factory: $factory,
+        );
+
+        $result = ($d->factory)(['type' => 't'], null);
+        $this->assertSame($marker, $result);
+    }
+}

--- a/tests/Unit/Notifications/ChannelFactoryTest.php
+++ b/tests/Unit/Notifications/ChannelFactoryTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ChannelFactory::class)]
 #[UsesClass(ChannelRegistry::class)]
 #[UsesClass(ChannelDescriptor::class)]
+#[UsesClass(Config::class)]
 final class ChannelFactoryTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Unit/Notifications/ChannelFactoryTest.php
+++ b/tests/Unit/Notifications/ChannelFactoryTest.php
@@ -6,77 +6,56 @@ namespace NwsCad\Tests\Unit\Notifications;
 
 use InvalidArgumentException;
 use NwsCad\Config;
+use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\ChannelFactory;
-use NwsCad\Notifications\Channels\NtfyChannel;
-use NwsCad\Notifications\Channels\PushoverChannel;
+use NwsCad\Notifications\ChannelRegistry;
+use NwsCad\Notifications\NotificationChannel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \NwsCad\Notifications\ChannelFactory
- * @uses \NwsCad\Config
- * @uses \NwsCad\Notifications\Channels\NtfyChannel
- * @uses \NwsCad\Notifications\Channels\PushoverChannel
- * @uses \NwsCad\Logging\SecretRegistry
- */
-class ChannelFactoryTest extends TestCase
+#[CoversClass(ChannelFactory::class)]
+#[UsesClass(ChannelRegistry::class)]
+#[UsesClass(ChannelDescriptor::class)]
+final class ChannelFactoryTest extends TestCase
 {
     protected function setUp(): void
     {
-        $_ENV['NTFY_AUTH_TOKEN']  = 'ntfy-token';
-        $_ENV['PUSHOVER_TOKEN']   = 'pushover-token';
-        $_ENV['PUSHOVER_USER']    = 'pushover-user';
+        ChannelRegistry::clear();
     }
 
     protected function tearDown(): void
     {
-        unset($_ENV['NTFY_AUTH_TOKEN'], $_ENV['PUSHOVER_TOKEN'], $_ENV['PUSHOVER_USER']);
-        putenv('NTFY_AUTH_TOKEN');
-        putenv('PUSHOVER_TOKEN');
-        putenv('PUSHOVER_USER');
+        ChannelRegistry::clear();
     }
 
-    public function testCreatesNtfyChannel(): void
+    public function testUnknownTypeThrows(): void
     {
         $factory = new ChannelFactory(Config::getInstance());
-        $channel = $factory->create([
-            'type'        => 'ntfy',
-            'base_url'    => 'https://ntfy.example',
-            'config_json' => '{"auth_token_env":"NTFY_AUTH_TOKEN"}',
-        ]);
-        $this->assertInstanceOf(NtfyChannel::class, $channel);
-    }
 
-    public function testCreatesPushoverChannel(): void
-    {
-        $factory = new ChannelFactory(Config::getInstance());
-        $channel = $factory->create([
-            'type'        => 'pushover',
-            'base_url'    => 'https://api.pushover.net',
-            'config_json' => '{"token_env":"PUSHOVER_TOKEN","user_env":"PUSHOVER_USER"}',
-        ]);
-        $this->assertInstanceOf(PushoverChannel::class, $channel);
-    }
-
-    public function testThrowsOnUnknownType(): void
-    {
-        $factory = new ChannelFactory(Config::getInstance());
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown channel type: webhook');
-        $factory->create([
-            'type'        => 'webhook',
-            'base_url'    => 'https://x',
+        $this->expectExceptionMessage('Unknown channel type: bogus');
+
+        $factory->create(['type' => 'bogus', 'base_url' => '', 'config_json' => '']);
+    }
+
+    public function testRegistryDispatchInvokesDescriptorFactory(): void
+    {
+        $stub = $this->createStub(NotificationChannel::class);
+
+        ChannelRegistry::register(new ChannelDescriptor(
+            type: 'demo', label: 'Demo', baseUrlEnv: 'DEMO_URL',
+            requiredEnvs: [], defaultConfig: [],
+            factory: static fn (array $row, Config $cfg): NotificationChannel => $stub,
+        ));
+
+        $factory = new ChannelFactory(Config::getInstance());
+        $result  = $factory->create([
+            'type'        => 'demo',
+            'base_url'    => 'http://example.test',
             'config_json' => '{}',
         ]);
-    }
 
-    public function testHandlesEmptyConfigJson(): void
-    {
-        $factory = new ChannelFactory(Config::getInstance());
-        $channel = $factory->create([
-            'type'        => 'ntfy',
-            'base_url'    => 'https://ntfy.example',
-            'config_json' => '',
-        ]);
-        $this->assertInstanceOf(NtfyChannel::class, $channel);
+        $this->assertSame($stub, $result);
     }
 }

--- a/tests/Unit/Notifications/ChannelRegistryTest.php
+++ b/tests/Unit/Notifications/ChannelRegistryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notifications;
+
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\ChannelRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ChannelRegistry::class)]
+#[UsesClass(ChannelDescriptor::class)]
+final class ChannelRegistryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ChannelRegistry::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        ChannelRegistry::clear();
+    }
+
+    private function descriptor(string $type): ChannelDescriptor
+    {
+        return new ChannelDescriptor(
+            type: $type, label: ucfirst($type),
+            baseUrlEnv: strtoupper($type) . '_BASE_URL',
+            requiredEnvs: [], defaultConfig: [],
+            factory: static fn (array $r, $c) => new \stdClass(),
+        );
+    }
+
+    public function testEmptyRegistry(): void
+    {
+        $this->assertSame([], ChannelRegistry::types());
+        $this->assertSame([], ChannelRegistry::all());
+        $this->assertFalse(ChannelRegistry::has('ntfy'));
+        $this->assertNull(ChannelRegistry::get('ntfy'));
+    }
+
+    public function testRegisterAndRetrieve(): void
+    {
+        $d = $this->descriptor('demo');
+        ChannelRegistry::register($d);
+
+        $this->assertTrue(ChannelRegistry::has('demo'));
+        $this->assertSame($d, ChannelRegistry::get('demo'));
+        $this->assertSame(['demo'], ChannelRegistry::types());
+        $this->assertSame(['demo' => $d], ChannelRegistry::all());
+    }
+
+    public function testDuplicateTypeOverwrites(): void
+    {
+        $first  = $this->descriptor('demo');
+        $second = $this->descriptor('demo');
+        ChannelRegistry::register($first);
+        ChannelRegistry::register($second);
+
+        $this->assertSame($second, ChannelRegistry::get('demo'));
+        $this->assertCount(1, ChannelRegistry::all());
+    }
+
+    public function testClearWipesState(): void
+    {
+        ChannelRegistry::register($this->descriptor('a'));
+        ChannelRegistry::register($this->descriptor('b'));
+        ChannelRegistry::clear();
+
+        $this->assertSame([], ChannelRegistry::types());
+    }
+}

--- a/tests/Unit/Notifications/ChannelRegistryTest.php
+++ b/tests/Unit/Notifications/ChannelRegistryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Notifications;
+namespace NwsCad\Tests\Unit\Notifications;
 
 use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\ChannelRegistry;

--- a/tests/Unit/Notifications/Channels/HttpPostJsonTest.php
+++ b/tests/Unit/Notifications/Channels/HttpPostJsonTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Unit\Notifications\Channels;
+
+use NwsCad\Notifications\Channels\HttpPost;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(HttpPost::class)]
+final class HttpPostJsonTest extends TestCase
+{
+    public function testPostJsonHits200OnLocalServer(): void
+    {
+        $server = $this->startEchoServer();
+        try {
+            $http   = new HttpPost();
+            $result = $http->postJson(
+                url: "http://127.0.0.1:{$server['port']}/",
+                payload: ['intent' => 'Created', 'topics' => ['A', 'B']],
+                timeoutSec: 5,
+                headers: ['Authorization' => 'Bearer test-token'],
+            );
+
+            $this->assertSame(200, $result['status']);
+            $this->assertStringContainsString('Created', $result['body']);
+            $this->assertStringContainsString('Bearer test-token', $result['body']);
+            $this->assertStringContainsString('application/json', $result['body']);
+        } finally {
+            $this->stopEchoServer($server);
+        }
+    }
+
+    /**
+     * @return array{proc:resource,port:int,scriptPath:string}
+     */
+    private function startEchoServer(): array
+    {
+        $port = $this->findFreePort();
+        $script = tempnam(sys_get_temp_dir(), 'echo') . '.php';
+        file_put_contents($script, <<<'PHP'
+<?php
+$body = file_get_contents('php://input') ?: '';
+$ct   = $_SERVER['HTTP_CONTENT_TYPE'] ?? '';
+$auth = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+header('Content-Type: text/plain');
+echo "body=$body|ct=$ct|auth=$auth";
+PHP);
+        $cmd = sprintf('php -S 127.0.0.1:%d %s', $port, escapeshellarg($script));
+        $proc = proc_open($cmd, [
+            0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w'],
+        ], $pipes);
+        if (! is_resource($proc)) {
+            $this->fail('failed to start local echo server');
+        }
+        $deadline = microtime(true) + 3.0;
+        while (microtime(true) < $deadline) {
+            $sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.2);
+            if ($sock !== false) { fclose($sock); break; }
+            usleep(50_000);
+        }
+        return ['proc' => $proc, 'port' => $port, 'scriptPath' => $script];
+    }
+
+    private function stopEchoServer(array $server): void
+    {
+        if (isset($server['proc']) && is_resource($server['proc'])) {
+            proc_terminate($server['proc']);
+            proc_close($server['proc']);
+        }
+        if (isset($server['scriptPath']) && file_exists($server['scriptPath'])) {
+            @unlink($server['scriptPath']);
+        }
+    }
+
+    private function findFreePort(): int
+    {
+        $sock = socket_create_listen(0);
+        if ($sock === false) { $this->fail('socket_create_listen failed'); }
+        socket_getsockname($sock, $addr, $port);
+        socket_close($sock);
+        return (int) $port;
+    }
+}

--- a/tests/Unit/Notifications/Channels/NtfyChannelDescriptorTest.php
+++ b/tests/Unit/Notifications/Channels/NtfyChannelDescriptorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Unit\Notifications\Channels;
+
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\Channels\NtfyChannel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NtfyChannel::class)]
+#[UsesClass(ChannelDescriptor::class)]
+final class NtfyChannelDescriptorTest extends TestCase
+{
+    public function testDescriptorReportsTypeAndDefaults(): void
+    {
+        $d = NtfyChannel::descriptor();
+
+        $this->assertInstanceOf(ChannelDescriptor::class, $d);
+        $this->assertSame('ntfy', $d->type);
+        $this->assertSame('ntfy.sh', $d->label);
+        $this->assertSame('NTFY_BASE_URL', $d->baseUrlEnv);
+        $this->assertSame(['NTFY_AUTH_TOKEN'], $d->requiredEnvs);
+        $this->assertSame(['auth_token_env' => 'NTFY_AUTH_TOKEN'], $d->defaultConfig);
+    }
+}

--- a/tests/Unit/Notifications/Channels/NtfyChannelDescriptorTest.php
+++ b/tests/Unit/Notifications/Channels/NtfyChannelDescriptorTest.php
@@ -23,6 +23,12 @@ final class NtfyChannelDescriptorTest extends TestCase
         $this->assertSame('ntfy.sh', $d->label);
         $this->assertSame('NTFY_BASE_URL', $d->baseUrlEnv);
         $this->assertSame(['NTFY_AUTH_TOKEN'], $d->requiredEnvs);
-        $this->assertSame(['auth_token_env' => 'NTFY_AUTH_TOKEN'], $d->defaultConfig);
+        $this->assertSame(
+            [
+                'auth_token_env'     => 'NTFY_AUTH_TOKEN',
+                'alarm_priority_map' => ['1' => 3, '2' => 4, '3' => 5],
+            ],
+            $d->defaultConfig,
+        );
     }
 }

--- a/tests/Unit/Notifications/Channels/PushoverChannelDescriptorTest.php
+++ b/tests/Unit/Notifications/Channels/PushoverChannelDescriptorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Unit\Notifications\Channels;
+
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\Channels\PushoverChannel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PushoverChannel::class)]
+#[UsesClass(ChannelDescriptor::class)]
+final class PushoverChannelDescriptorTest extends TestCase
+{
+    public function testDescriptorReportsTypeAndDefaults(): void
+    {
+        $d = PushoverChannel::descriptor();
+
+        $this->assertInstanceOf(ChannelDescriptor::class, $d);
+        $this->assertSame('pushover', $d->type);
+        $this->assertSame('Pushover', $d->label);
+        $this->assertSame('PUSHOVER_BASE_URL', $d->baseUrlEnv);
+        $this->assertSame(['PUSHOVER_TOKEN', 'PUSHOVER_USER'], $d->requiredEnvs);
+        $this->assertSame(
+            ['token_env' => 'PUSHOVER_TOKEN', 'user_env' => 'PUSHOVER_USER'],
+            $d->defaultConfig,
+        );
+    }
+}

--- a/tests/Unit/Notifications/Channels/WebhookChannelTest.php
+++ b/tests/Unit/Notifications/Channels/WebhookChannelTest.php
@@ -4,22 +4,24 @@ declare(strict_types=1);
 
 namespace NwsCad\Tests\Unit\Notifications\Channels;
 
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\Channels\HttpPost;
 use NwsCad\Notifications\Channels\WebhookChannel;
 use NwsCad\Notifications\Events\Intent;
 use NwsCad\Notifications\IncidentDto;
 use NwsCad\Notifications\NotificationContext;
+use NwsCad\Notifications\SendResult;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @uses \NwsCad\Notifications\ChannelDescriptor
- * @uses \NwsCad\Notifications\IncidentDto
- * @uses \NwsCad\Notifications\NotificationContext
- * @uses \NwsCad\Notifications\SendResult
- * @uses \NwsCad\Notifications\Events\Intent
- * @uses \NwsCad\Notifications\Channels\HttpPost
- */
 #[CoversClass(WebhookChannel::class)]
+#[UsesClass(ChannelDescriptor::class)]
+#[UsesClass(IncidentDto::class)]
+#[UsesClass(NotificationContext::class)]
+#[UsesClass(SendResult::class)]
+#[UsesClass(Intent::class)]
+#[UsesClass(HttpPost::class)]
 final class WebhookChannelTest extends TestCase
 {
     private function dto(): IncidentDto

--- a/tests/Unit/Notifications/Channels/WebhookChannelTest.php
+++ b/tests/Unit/Notifications/Channels/WebhookChannelTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Unit\Notifications\Channels;
+
+use NwsCad\Notifications\Channels\WebhookChannel;
+use NwsCad\Notifications\Events\Intent;
+use NwsCad\Notifications\IncidentDto;
+use NwsCad\Notifications\NotificationContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @uses \NwsCad\Notifications\ChannelDescriptor
+ * @uses \NwsCad\Notifications\IncidentDto
+ * @uses \NwsCad\Notifications\NotificationContext
+ * @uses \NwsCad\Notifications\SendResult
+ * @uses \NwsCad\Notifications\Events\Intent
+ * @uses \NwsCad\Notifications\Channels\HttpPost
+ */
+#[CoversClass(WebhookChannel::class)]
+final class WebhookChannelTest extends TestCase
+{
+    private function dto(): IncidentDto
+    {
+        return IncidentDto::fromRow([
+            'id'              => 1,
+            'call_id'         => 42,
+            'call_number'     => 'CN-100',
+            'call_type'       => 'STRUCT FIRE',
+            'agency_type'     => 'FIRE',
+            'jurisdiction'    => 'CityA|CityB',
+            'units'           => 'E1|L2',
+            'common_name'     => null,
+            'full_address'    => '123 Main St',
+            'nearest_cross_streets' => null,
+            'police_beat'     => null,
+            'fire_quadrant'   => null,
+            'nature_of_call'  => null,
+            'narrative'       => 'large flames visible',
+            'alarm_level'     => 2,
+            'create_datetime' => '2026-05-12T10:00:00Z',
+            'latitude'        => null,
+            'longitude'       => null,
+        ]);
+    }
+
+    private function context(): NotificationContext
+    {
+        return new NotificationContext(
+            intent: Intent::Created,
+            resendAll: true,
+            topicsToNotify: ['FIRE', 'E1', 'L2'],
+            channelConfig: [],
+        );
+    }
+
+    public function testStringPlaceholderSubstitution(): void
+    {
+        $payload = WebhookChannel::buildPayload(
+            template: ['text' => '{intent}: {call_type} at {full_address}'],
+            dto: $this->dto(),
+            context: $this->context(),
+        );
+        $this->assertSame(
+            '{"text":"Created: STRUCT FIRE at 123 Main St"}',
+            $payload,
+        );
+    }
+
+    public function testRawArrayPlaceholderSubstitution(): void
+    {
+        $payload = WebhookChannel::buildPayload(
+            template: ['topics' => '${topics}'],
+            dto: $this->dto(),
+            context: $this->context(),
+        );
+        $this->assertSame(
+            '{"topics":["FIRE","E1","L2"]}',
+            $payload,
+        );
+    }
+
+    public function testUnknownPlaceholderPassesThrough(): void
+    {
+        $payload = WebhookChannel::buildPayload(
+            template: ['text' => 'hi {unknown_thing}'],
+            dto: $this->dto(),
+            context: $this->context(),
+        );
+        $this->assertStringContainsString('{unknown_thing}', $payload);
+    }
+
+    public function testRawUnitsAndJurisdictionSplit(): void
+    {
+        $payload = WebhookChannel::buildPayload(
+            template: ['u' => '${units}', 'j' => '${jurisdiction}'],
+            dto: $this->dto(),
+            context: $this->context(),
+        );
+        $decoded = json_decode($payload, true);
+        $this->assertSame(['E1', 'L2'], $decoded['u']);
+        $this->assertSame(['CityA', 'CityB'], $decoded['j']);
+    }
+
+    public function testMissingTemplateThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('webhook: template required');
+
+        new WebhookChannel(
+            baseUrl: 'https://example.test/hook',
+            config: ['template' => null],
+        );
+    }
+
+    public function testCrLfInAuthTokenRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CR/LF');
+
+        new WebhookChannel(
+            baseUrl: 'https://example.test/hook',
+            config: ['template' => ['text' => 'x']],
+            authToken: "ok\r\nInjected: header",
+        );
+    }
+}

--- a/tests/Unit/Notifications/RegisterChannelsBootTest.php
+++ b/tests/Unit/Notifications/RegisterChannelsBootTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Unit\Notifications;
+
+use NwsCad\Notifications\ChannelDescriptor;
+use NwsCad\Notifications\ChannelRegistry;
+use NwsCad\Notifications\Channels\NtfyChannel;
+use NwsCad\Notifications\Channels\PushoverChannel;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+#[UsesClass(ChannelRegistry::class)]
+#[UsesClass(ChannelDescriptor::class)]
+#[UsesClass(NtfyChannel::class)]
+#[UsesClass(PushoverChannel::class)]
+final class RegisterChannelsBootTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ChannelRegistry::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        ChannelRegistry::clear();
+    }
+
+    public function testIncludePopulatesRegistryWithNtfyAndPushover(): void
+    {
+        require __DIR__ . '/../../../src/Notifications/registerChannels.php';
+
+        $this->assertEqualsCanonicalizing(
+            ['ntfy', 'pushover'],
+            ChannelRegistry::types(),
+            'registerChannels.php must register the built-in channel types',
+        );
+    }
+}

--- a/tests/Unit/Notifications/RegisterChannelsBootTest.php
+++ b/tests/Unit/Notifications/RegisterChannelsBootTest.php
@@ -8,6 +8,7 @@ use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\ChannelRegistry;
 use NwsCad\Notifications\Channels\NtfyChannel;
 use NwsCad\Notifications\Channels\PushoverChannel;
+use NwsCad\Notifications\Channels\WebhookChannel;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
@@ -17,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(ChannelDescriptor::class)]
 #[UsesClass(NtfyChannel::class)]
 #[UsesClass(PushoverChannel::class)]
+#[UsesClass(WebhookChannel::class)]
 final class RegisterChannelsBootTest extends TestCase
 {
     protected function setUp(): void
@@ -29,12 +31,12 @@ final class RegisterChannelsBootTest extends TestCase
         ChannelRegistry::clear();
     }
 
-    public function testIncludePopulatesRegistryWithNtfyAndPushover(): void
+    public function testIncludePopulatesRegistry(): void
     {
         require __DIR__ . '/../../../src/Notifications/registerChannels.php';
 
         $this->assertEqualsCanonicalizing(
-            ['ntfy', 'pushover'],
+            ['ntfy', 'pushover', 'webhook'],
             ChannelRegistry::types(),
             'registerChannels.php must register the built-in channel types',
         );


### PR DESCRIPTION
## Summary

- Introduce `ChannelRegistry` and `ChannelDescriptor` so per-channel-type knowledge lives in one class per channel. Adding a new transport is now one new class + one line in `src/Notifications/registerChannels.php` — no edits to `ChannelFactory`, `NotificationsController`, or `bin/notifications.php`.
- Ship `WebhookChannel` as the first consumer of the new abstraction: one HTTP POST per `CallProcessedEvent` with a JSON payload built from a per-row template in `notification_channels.config_json`. Covers Slack, Discord, Mattermost, Home Assistant and similar incoming-webhook integrations via configuration alone.
- Remove the unused `NotificationChannel::type()` interface method now that `descriptor()->type` replaces it.

## Behavior changes

- `/api/notifications/{type}/enable|disable|test|clear` returns HTTP **400** (was 404) on unknown channel type, with `errors.available_types` populated for UI dropdowns.
- `bin/notifications.php` error/help text is now generated dynamically from the registry; unknown types print `Available: ntfy, pushover, webhook`.
- Default `config_json` on new ntfy channels now sources from `NtfyChannel::descriptor()->defaultConfig`; restored `alarm_priority_map` that was missing in earlier task iterations (regression fix).

## Schema and migration

- **None.** Schema unchanged. Existing `ntfy` / `pushover` rows continue to work as soon as the registry is populated at boot.

## Template syntax (WebhookChannel)

Two placeholder types:
- `{name}` — string substitution (e.g., `{intent}`, `{full_address}`, `{topics}` comma-joined). 12 placeholders supported.
- `\"\${name}\"` — raw JSON array (only `topics`, `units`, `jurisdiction`). Must appear as the entire string value of a JSON field.

See `docs/NOTIFICATIONS.md` for the full reference plus Slack/Discord example templates.

## Test plan

- [x] 18 new unit + integration tests, all green
- [x] No regressions vs. baseline (20 pre-existing log-permission / pdo_mysql env errors remain unchanged)
- [x] Per-task spec compliance + code-quality reviews passed (subagent-driven workflow)
- [x] Final holistic branch review passed
- [x] `WebhookEndToEndTest` spins up a local PHP capture server and validates one POST per event with substituted body + topics JSON array
- [x] CLI smoke: `php bin/notifications.php enable badtype` prints `Available: ntfy, pushover, webhook`
- [ ] Re-verify in the deployed environment after merge

## Follow-ups (deferred, not blocking)

1. Rename `test*Returns404ForUnknownType` methods in `NotificationsApiTest` to match the new 400 behavior
2. Standardize 4xx-failure logging across all three channels (ntfy logs once, pushover/webhook log twice)
3. Convert `WebhookChannelTest`'s `@uses` docblock tags to `#[UsesClass]` attributes for consistency

## Design + plan docs

- Spec: \`docs/superpowers/specs/2026-05-12-channel-registry-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-12-channel-registry.md\` (13 TDD-ordered tasks with complete code in every step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)