### PR TITLE
chore(notifications): final factory via interface; consistent 4xx logging

### DIFF
--- a/src/Api/Controllers/NotificationsController.php
+++ b/src/Api/Controllers/NotificationsController.php
@@ -8,6 +8,7 @@ use NwsCad\Api\Response;
 use NwsCad\Config;
 use NwsCad\Database;
 use NwsCad\Notifications\ChannelFactory;
+use NwsCad\Notifications\ChannelFactoryInterface;
 use NwsCad\Notifications\ChannelRegistry;
 use NwsCad\Notifications\ChannelRepository;
 use NwsCad\Notifications\IncidentDto;
@@ -20,10 +21,10 @@ use Exception;
 final class NotificationsController
 {
     private PDO $db;
-    private ChannelFactory $factory;
+    private ChannelFactoryInterface $factory;
     private ChannelRepository $repo;
 
-    public function __construct(?ChannelFactory $factory = null, ?ChannelRepository $repo = null)
+    public function __construct(?ChannelFactoryInterface $factory = null, ?ChannelRepository $repo = null)
     {
         $this->db = Database::getConnection();
         $this->factory = $factory ?? new ChannelFactory(Config::getInstance());

--- a/src/Notifications/ChannelFactory.php
+++ b/src/Notifications/ChannelFactory.php
@@ -7,7 +7,7 @@ namespace NwsCad\Notifications;
 use InvalidArgumentException;
 use NwsCad\Config;
 
-class ChannelFactory
+final class ChannelFactory implements ChannelFactoryInterface
 {
     public function __construct(private readonly Config $config)
     {

--- a/src/Notifications/ChannelFactoryInterface.php
+++ b/src/Notifications/ChannelFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Notifications;
+
+interface ChannelFactoryInterface
+{
+    /**
+     * @param array{type:string,base_url:string,config_json:string} $row
+     */
+    public function create(array $row): NotificationChannel;
+}

--- a/src/Notifications/Channels/PushoverChannel.php
+++ b/src/Notifications/Channels/PushoverChannel.php
@@ -101,7 +101,8 @@ final class PushoverChannel implements NotificationChannel
                     'attempt' => $i + 1,
                     'body' => substr($lastError, 0, 500),
                 ]);
-                break;
+                $duration = (int) ((microtime(true) - $start) * 1000);
+                return [SendResult::fail($resp['status'], $duration, $lastError)];
             }
 
             if ($i < count(self::BACKOFF_MS) - 1) {

--- a/src/Notifications/Channels/WebhookChannel.php
+++ b/src/Notifications/Channels/WebhookChannel.php
@@ -126,7 +126,11 @@ final class WebhookChannel implements NotificationChannel
                     'baseUrl'    => $this->baseUrl,
                     'httpStatus' => $lastStatus,
                 ]);
-                break;   // permanent
+                return [SendResult::fail(
+                    httpStatus: $lastStatus,
+                    durationMs: (int) ((microtime(true) - $startedAt) * 1000),
+                    error:      $lastError ?? 'unknown',
+                )];
             }
             // 5xx and 0 (network) → retry
         }

--- a/tests/Integration/Notifications/WebhookEndToEndTest.php
+++ b/tests/Integration/Notifications/WebhookEndToEndTest.php
@@ -7,6 +7,7 @@ namespace NwsCad\Tests\Integration\Notifications;
 use DateTimeImmutable;
 use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\ChannelFactory;
+use NwsCad\Notifications\ChannelFactoryInterface;
 use NwsCad\Notifications\ChannelRegistry;
 use NwsCad\Notifications\Channels\WebhookChannel;
 use NwsCad\Notifications\Events\CallProcessedEvent;
@@ -23,6 +24,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(ChannelRegistry::class)]
 #[UsesClass(ChannelDescriptor::class)]
 #[UsesClass(ChannelFactory::class)]
+#[UsesClass(ChannelFactoryInterface::class)]
 #[UsesClass(NotificationDispatcher::class)]
 #[UsesClass(IncidentDto::class)]
 #[UsesClass(SendResult::class)]

--- a/tests/Integration/NotificationsApiTest.php
+++ b/tests/Integration/NotificationsApiTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
  * @uses \NwsCad\Logging\RedactingProcessor
  * @uses \NwsCad\Logging\SecretRegistry
  * @uses \NwsCad\Notifications\ChannelFactory
+ * @uses \NwsCad\Notifications\ChannelFactoryInterface
  * @uses \NwsCad\Notifications\ChannelRegistry
  * @uses \NwsCad\Notifications\ChannelDescriptor
  * @uses \NwsCad\Notifications\ChannelRepository
@@ -173,15 +174,16 @@ class NotificationsApiTest extends TestCase
         )->fetchColumn());
     }
 
-    public function testEnableReturns404ForUnknownType(): void
+    public function testEnableReturns400ForUnknownType(): void
     {
         $controller = new NotificationsController();
         ob_start();
-        $controller->enable('webhook');
+        $controller->enable('bogus');
         $payload = json_decode((string) ob_get_clean(), true);
 
         $this->assertFalse($payload['success']);
         $this->assertStringContainsString('Unknown channel type', $payload['error']);
+        $this->assertSame(400, http_response_code());
     }
 
     public function testDisableSetsEnabledToZero(): void
@@ -212,14 +214,15 @@ class NotificationsApiTest extends TestCase
         $this->assertSame(0, (int) $payload['data']['updated']);
     }
 
-    public function testDisableReturns404ForUnknownType(): void
+    public function testDisableReturns400ForUnknownType(): void
     {
         $controller = new NotificationsController();
         ob_start();
-        $controller->disable('webhook');
+        $controller->disable('bogus');
         $payload = json_decode((string) ob_get_clean(), true);
 
         $this->assertFalse($payload['success']);
+        $this->assertSame(400, http_response_code());
     }
 
     public function testTestReturns422WhenChannelMissing(): void
@@ -266,10 +269,8 @@ class NotificationsApiTest extends TestCase
             }
         };
 
-        $factory = new class($stub) extends \NwsCad\Notifications\ChannelFactory {
-            public function __construct(private $stub) {
-                parent::__construct(\NwsCad\Config::getInstance());
-            }
+        $factory = new class($stub) implements \NwsCad\Notifications\ChannelFactoryInterface {
+            public function __construct(private \NwsCad\Notifications\NotificationChannel $stub) {}
             public function create(array $row): \NwsCad\Notifications\NotificationChannel { return $this->stub; }
         };
 
@@ -309,10 +310,8 @@ class NotificationsApiTest extends TestCase
                 return [\NwsCad\Notifications\SendResult::fail(503, 9, 'Service Unavailable', 'test')];
             }
         };
-        $factory = new class($stub) extends \NwsCad\Notifications\ChannelFactory {
-            public function __construct(private $stub) {
-                parent::__construct(\NwsCad\Config::getInstance());
-            }
+        $factory = new class($stub) implements \NwsCad\Notifications\ChannelFactoryInterface {
+            public function __construct(private \NwsCad\Notifications\NotificationChannel $stub) {}
             public function create(array $row): \NwsCad\Notifications\NotificationChannel { return $this->stub; }
         };
 
@@ -332,14 +331,15 @@ class NotificationsApiTest extends TestCase
         $this->assertSame(0, (int) $logged);
     }
 
-    public function testTestReturns404ForUnknownType(): void
+    public function testTestReturns400ForUnknownType(): void
     {
         $controller = new NotificationsController();
         ob_start();
-        $controller->test('webhook');
+        $controller->test('bogus');
         $payload = json_decode((string) ob_get_clean(), true);
 
         $this->assertFalse($payload['success']);
+        $this->assertSame(400, http_response_code());
     }
 
     public function testEnableRejectsHttpUrl(): void

--- a/tests/Integration/Security/IdentityRoundtripTest.php
+++ b/tests/Integration/Security/IdentityRoundtripTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\TestCase;
  * @uses \NwsCad\Logging\SecretRegistry
  * @uses \NwsCad\Notifications\ChannelDescriptor
  * @uses \NwsCad\Notifications\ChannelFactory
+ * @uses \NwsCad\Notifications\ChannelFactoryInterface
  * @uses \NwsCad\Notifications\ChannelRegistry
  * @uses \NwsCad\Notifications\ChannelRepository
  * @uses \NwsCad\Notifications\Channels\NtfyChannel

--- a/tests/Unit/Notifications/ChannelFactoryTest.php
+++ b/tests/Unit/Notifications/ChannelFactoryTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use NwsCad\Config;
 use NwsCad\Notifications\ChannelDescriptor;
 use NwsCad\Notifications\ChannelFactory;
+use NwsCad\Notifications\ChannelFactoryInterface;
 use NwsCad\Notifications\ChannelRegistry;
 use NwsCad\Notifications\NotificationChannel;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -15,6 +16,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ChannelFactory::class)]
+#[UsesClass(ChannelFactoryInterface::class)]
 #[UsesClass(ChannelRegistry::class)]
 #[UsesClass(ChannelDescriptor::class)]
 #[UsesClass(Config::class)]


### PR DESCRIPTION
## Summary
Three small follow-ups deferred from PR #24:

- **ChannelFactoryInterface + `final ChannelFactory`.** Carve a minimal interface out of `ChannelFactory::create()`. `NotificationsController` depends on the interface; the anonymous test stubs in `NotificationsApiTest` implement the interface directly instead of extending the concrete class. The concrete factory is now `final` (the original reviewer nudge from Task 5 in the registry plan).
- **Consistent 4xx logging.** Both `PushoverChannel` and `WebhookChannel` previously logged `warning('permanent failure')` AND then fell through to `error('retries exhausted')` for any client error. They now match `NtfyChannel`: log the warning and return immediately. No more double-log entries for the same 4xx.
- **Test renames.** `test*Returns404ForUnknownType` → `test*Returns400ForUnknownType` (the controller has been returning 400 since the registry merge), and the renamed tests now assert `http_response_code() === 400` explicitly so the name and behavior can't drift apart again.

## Test plan
- [x] `phpunit tests/Unit/Notifications tests/Integration/NotificationsApiTest.php tests/Integration/Notifications tests/Integration/Security/IdentityRoundtripTest.php` — only failures are the pre-existing `socket_create_listen` extension misses in the local container (CI has the `sockets` ext).
- [x] Touched-test slice (`--filter testEnableReturns400ForUnknownType|testDisableReturns400ForUnknownType|testTestReturns400ForUnknownType|testTestSendsAndLogsSuccess|testTestLogsFailureWhenChannelReturnsFail|testRegistryDispatchInvokesDescriptorFactory|testUnknownTypeThrows|testEnableRecordsExtractedIdentity`) — 8/8 green.
- [ ] CI Tests workflow on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)