### PR TITLE
chore(tests): hermetic env handling + sockets-ext skip + quiet code-style step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,8 +189,9 @@ jobs:
 
       - name: Code Style Check
         run: |
-          # Check for PHP syntax errors
-          find src -name "*.php" -exec php -l {} \; | grep -v "No syntax errors"
+          # Surface only files with syntax errors. grep -v exits 1 when all
+          # files pass (no matching lines); we explicitly succeed in that case.
+          find src -name "*.php" -exec php -l {} \; | grep -v "No syntax errors" || true
         continue-on-error: true
 
       - name: Generate test summary

--- a/tests/Integration/Notifications/WebhookEndToEndTest.php
+++ b/tests/Integration/Notifications/WebhookEndToEndTest.php
@@ -53,6 +53,9 @@ final class WebhookEndToEndTest extends TestCase
 
     protected function setUp(): void
     {
+        if (! function_exists('socket_create_listen')) {
+            $this->markTestSkipped('ext-sockets not available — needed for capture-server fixture');
+        }
         cleanTestDatabase();
         ChannelRegistry::clear();
     }

--- a/tests/Integration/Security/BootstrapTrustGuardTest.php
+++ b/tests/Integration/Security/BootstrapTrustGuardTest.php
@@ -27,6 +27,16 @@ class BootstrapTrustGuardTest extends TestCase
         Response::resetForTesting();
         $this->initialObLevel = ob_get_level();
         ob_start();
+
+        // Pin trusted CIDRs to loopback for the test regardless of the
+        // developer's .env (which may permit broader ranges for direct-LAN
+        // deployments). Reset the singleton so the new value sticks.
+        $_ENV['TRUSTED_PROXY_CIDRS'] = '127.0.0.1/32,::1/128';
+        putenv('TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128');
+        $refl = new \ReflectionClass(Config::class);
+        $prop = $refl->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null, null);
     }
 
     protected function tearDown(): void

--- a/tests/Security/DirectAccessForgeryTest.php
+++ b/tests/Security/DirectAccessForgeryTest.php
@@ -37,6 +37,16 @@ class DirectAccessForgeryTest extends TestCase
         unset($GLOBALS['__identity']);
         $this->initialObLevel = ob_get_level();
         ob_start();
+
+        // Pin trusted CIDRs to loopback so this test exercises the deny path
+        // regardless of the developer's .env (some LAN deployments widen the
+        // default to 0.0.0.0/0 for direct access).
+        $_ENV['TRUSTED_PROXY_CIDRS'] = '127.0.0.1/32,::1/128';
+        putenv('TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128');
+        $refl = new \ReflectionClass(Config::class);
+        $prop = $refl->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null, null);
     }
 
     protected function tearDown(): void

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -145,8 +145,11 @@ class ConfigTest extends TestCase
 
     public function testTrustedProxyCidrsDefaultIncludesLoopback(): void
     {
-        unset($_ENV['TRUSTED_PROXY_CIDRS']);
-        putenv('TRUSTED_PROXY_CIDRS');
+        // Empty-string assignment defeats Config's loadEnvFile() re-load
+        // (which would silently pull a value back in from a developer's .env)
+        // while still triggering env()'s falsy-default branch.
+        $_ENV['TRUSTED_PROXY_CIDRS'] = '';
+        putenv('TRUSTED_PROXY_CIDRS=');
         $reflection = new \ReflectionClass(\NwsCad\Config::class);
         $prop = $reflection->getProperty('instance');
         $prop->setAccessible(true);
@@ -160,8 +163,8 @@ class ConfigTest extends TestCase
 
     public function testIdentityHeaderDefaultsToXAuthUser(): void
     {
-        unset($_ENV['PROXY_IDENTITY_HEADER']);
-        putenv('PROXY_IDENTITY_HEADER');
+        $_ENV['PROXY_IDENTITY_HEADER'] = '';
+        putenv('PROXY_IDENTITY_HEADER=');
         $reflection = new \ReflectionClass(\NwsCad\Config::class);
         $prop = $reflection->getProperty('instance');
         $prop->setAccessible(true);

--- a/tests/Unit/Notifications/Channels/HttpPostJsonTest.php
+++ b/tests/Unit/Notifications/Channels/HttpPostJsonTest.php
@@ -11,6 +11,13 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(HttpPost::class)]
 final class HttpPostJsonTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (! function_exists('socket_create_listen')) {
+            $this->markTestSkipped('ext-sockets not available — needed for ephemeral local server');
+        }
+    }
+
     public function testPostJsonHits200OnLocalServer(): void
     {
         $server = $this->startEchoServer();


### PR DESCRIPTION
## Summary
Three small cleanups so the local suite runs clean and the CI workflow log stops showing a misleading red X:

1. **Hermetic Config-default tests** — four tests reset env vars and the Config singleton, expecting code defaults to apply. They didn't account for `Config::loadEnvFile()` running on every new instance: the developer's `.env` value silently re-populates `$_ENV` because of the `!isset($_ENV[$key])` guard. Setting `$_ENV[key] = ''` + `putenv('key=')` short-circuits the reload AND triggers `env()`'s `?:` default branch. Fixes:
   - `ConfigTest::testTrustedProxyCidrsDefaultIncludesLoopback`
   - `ConfigTest::testIdentityHeaderDefaultsToXAuthUser`
   - `BootstrapTrustGuardTest::testUntrustedRemoteIs403`
   - `DirectAccessForgeryTest::testUntrustedRemoteCannotForgeIdentity`

2. **ext-sockets skip guards** — two tests need `socket_create_listen` for ephemeral local servers; CI has the extension, the dev container doesn't. `markTestSkipped` instead of throwing:
   - `HttpPostJsonTest::testPostJsonHits200OnLocalServer`
   - `WebhookEndToEndTest::testProducerThenConsumerDeliversToWebhookOnce`

3. **CI Code Style Check noise** — `find ... | grep -v "No syntax errors"` exits 1 when all files pass (no matching lines). The step has `continue-on-error: true` so it never blocked CI, but it left a red X in the workflow log. Appending `|| true` makes the step's exit status match its semantic intent.

## Test plan
- [x] Local full suite: 462 tests, 3 skipped (sockets ext + 1 pre-existing), 0 failures
- [x] Specifically: 4 failing tests now pass, 2 erroring tests now skip cleanly
- [ ] CI Tests workflow on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)