### PR TITLE
feat(notifications): outbox admin endpoints + dashboard queue card

### DIFF
--- a/public/api.php
+++ b/public/api.php
@@ -15,6 +15,7 @@ use NwsCad\Api\Controllers\SearchController;
 use NwsCad\Api\Controllers\StatsController;
 use NwsCad\Api\Controllers\LogsController;
 use NwsCad\Api\Controllers\NotificationsController;
+use NwsCad\Api\Controllers\OutboxController;
 use NwsCad\Api\Controllers\HealthController;
 use NwsCad\Api\Controllers\FilterOptionsController;
 
@@ -98,6 +99,12 @@ $router->post('/notifications/channels/{type}/test',    [NotificationsController
 $router->post('/notifications/channels/{type}/clear-error', [NotificationsController::class, 'clearChannelError']);
 $router->delete('/notifications/log/{id}',              [NotificationsController::class, 'dismissLogEntry']);
 $router->post('/notifications/log/clear-failed',        [NotificationsController::class, 'clearFailed']);
+
+// Outbox Controller Routes (operator admin for notification_outbox queue)
+$router->get('/notifications/outbox',                [OutboxController::class, 'index']);
+$router->post('/notifications/outbox/{id}/retry',    [OutboxController::class, 'retry']);
+$router->delete('/notifications/outbox/{id}',        [OutboxController::class, 'dismiss']);
+$router->post('/notifications/outbox/clear',         [OutboxController::class, 'clear']);
 
 // Logs Controller Routes
 $router->get('/logs', [LogsController::class, 'index']);

--- a/src/Api/Controllers/OutboxController.php
+++ b/src/Api/Controllers/OutboxController.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Api\Controllers;
+
+use NwsCad\Api\Response;
+use NwsCad\Database;
+use NwsCad\Notifications\Outbox\OutboxRepository;
+use NwsCad\Notifications\Outbox\OutboxRepositoryInterface;
+use Exception;
+
+/**
+ * Operator-facing admin controller for the notification outbox queue.
+ * Read-only listing plus per-row retry/dismiss and bulk clear-by-status.
+ */
+final class OutboxController
+{
+    private const ALLOWED_STATUSES = ['pending', 'in_flight', 'done', 'failed', 'all'];
+    private const ALLOWED_BULK_STATUSES = ['done', 'failed'];
+
+    private OutboxRepositoryInterface $repo;
+
+    public function __construct(?OutboxRepositoryInterface $repo = null)
+    {
+        $this->repo = $repo ?? new OutboxRepository(Database::getConnection());
+    }
+
+    /** GET /api/notifications/outbox?status=pending|in_flight|done|failed|all&limit=N */
+    public function index(): void
+    {
+        try {
+            $status = (string) ($_GET['status'] ?? 'pending');
+            if (! in_array($status, self::ALLOWED_STATUSES, true)) {
+                Response::error('Invalid status', 400, [
+                    'allowed_statuses' => self::ALLOWED_STATUSES,
+                ]);
+                return;
+            }
+            $limit = max(1, min(200, (int) ($_GET['limit'] ?? 50)));
+            $rows  = $this->repo->listByStatus($status, $limit);
+            Response::success(['items' => $rows, 'status' => $status, 'limit' => $limit]);
+        } catch (Exception $e) {
+            Response::error('Failed to list outbox: ' . $e->getMessage(), 500);
+        }
+    }
+
+    /** POST /api/notifications/outbox/{id}/retry */
+    public function retry(string $id): void
+    {
+        try {
+            if (! ctype_digit($id)) {
+                Response::error('Invalid outbox id', 400);
+                return;
+            }
+            $ok = $this->repo->retry((int) $id);
+            if (! $ok) {
+                Response::error('Outbox row not found', 404);
+                return;
+            }
+            Response::success(['retried' => 1, 'id' => (int) $id]);
+        } catch (Exception $e) {
+            Response::error('Failed to retry outbox row: ' . $e->getMessage(), 500);
+        }
+    }
+
+    /** DELETE /api/notifications/outbox/{id} */
+    public function dismiss(string $id): void
+    {
+        try {
+            if (! ctype_digit($id)) {
+                Response::error('Invalid outbox id', 400);
+                return;
+            }
+            $ok = $this->repo->delete((int) $id);
+            if (! $ok) {
+                Response::error('Outbox row not found', 404);
+                return;
+            }
+            Response::success(['deleted' => 1, 'id' => (int) $id]);
+        } catch (Exception $e) {
+            Response::error('Failed to dismiss outbox row: ' . $e->getMessage(), 500);
+        }
+    }
+
+    /** POST /api/notifications/outbox/clear?status=done|failed */
+    public function clear(): void
+    {
+        try {
+            $status = (string) ($_GET['status'] ?? $_POST['status'] ?? '');
+            if (! in_array($status, self::ALLOWED_BULK_STATUSES, true)) {
+                Response::error('Invalid status for bulk clear', 400, [
+                    'allowed_statuses' => self::ALLOWED_BULK_STATUSES,
+                ]);
+                return;
+            }
+            $count = $this->repo->deleteByStatus($status);
+            Response::success(['deleted' => $count, 'status' => $status]);
+        } catch (Exception $e) {
+            Response::error('Failed to clear outbox: ' . $e->getMessage(), 500);
+        }
+    }
+}

--- a/src/Dashboard/Views/notifications.php
+++ b/src/Dashboard/Views/notifications.php
@@ -177,6 +177,49 @@ body:has(#notifications-channels-container) > footer {
 }
 
 .clear-failed-btn { font-size: 0.75rem; }
+
+/* Outbox queue card */
+#outbox-queue-card {
+    margin-top: 1rem;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+}
+#outbox-queue-card .card-header {
+    background: #f8fafc;
+    border-bottom: 1px solid #e2e8f0;
+}
+#outbox-queue-table {
+    font-size: 0.85rem;
+}
+#outbox-queue-table th {
+    font-weight: 600;
+    color: #475569;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+}
+#outbox-queue-table td.error-cell {
+    max-width: 24em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    font-size: 0.75rem;
+    color: #991b1b;
+}
+.outbox-status-pill {
+    display: inline-block;
+    font-size: 0.7rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+.outbox-status-pill.pending   { background: #fef3c7; color: #92400e; }
+.outbox-status-pill.in_flight { background: #dbeafe; color: #1e40af; }
+.outbox-status-pill.done      { background: #dcfce7; color: #166534; }
+.outbox-status-pill.failed    { background: #fee2e2; color: #991b1b; }
 </style>
 
 <div class="dashboard-banner d-flex justify-content-between align-items-center flex-wrap gap-2">
@@ -200,6 +243,53 @@ body:has(#notifications-channels-container) > footer {
 </p>
 
 <div id="notifications-channels-container" class="row g-3"></div>
+
+<div id="outbox-queue-card" class="card">
+    <div class="card-header d-flex justify-content-between align-items-center flex-wrap gap-2">
+        <div class="d-flex align-items-center gap-2">
+            <strong><i class="bi bi-inbox"></i> Outbox queue</strong>
+            <div class="btn-group btn-group-sm" role="group" aria-label="Filter by status" id="outbox-status-tabs">
+                <button type="button" class="btn btn-outline-secondary active" data-status="pending">Pending</button>
+                <button type="button" class="btn btn-outline-secondary" data-status="in_flight">In flight</button>
+                <button type="button" class="btn btn-outline-secondary" data-status="failed">Failed</button>
+                <button type="button" class="btn btn-outline-secondary" data-status="done">Done</button>
+                <button type="button" class="btn btn-outline-secondary" data-status="all">All</button>
+            </div>
+        </div>
+        <div class="d-flex align-items-center gap-2">
+            <span id="outbox-row-count" class="small text-muted"></span>
+            <button type="button" class="btn btn-sm btn-outline-secondary" id="outbox-refresh-btn" title="Refresh">
+                <i class="bi bi-arrow-clockwise"></i>
+            </button>
+            <button type="button" class="btn btn-sm btn-outline-danger" id="outbox-clear-btn" hidden>
+                <i class="bi bi-trash"></i> Clear all <span id="outbox-clear-status-label"></span>
+            </button>
+        </div>
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table id="outbox-queue-table" class="table table-sm table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Status</th>
+                        <th>Channel</th>
+                        <th>Call</th>
+                        <th>Intent</th>
+                        <th>Attempts</th>
+                        <th>Next attempt</th>
+                        <th>Last error</th>
+                        <th>Updated</th>
+                        <th class="text-end">Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="outbox-queue-tbody">
+                    <tr><td colspan="10" class="text-center text-muted py-3 small">Loading&hellip;</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
 
 <template id="channel-card-template">
     <div class="col-md-6">
@@ -752,6 +842,184 @@ body:has(#notifications-channels-container) > footer {
         document.addEventListener('DOMContentLoaded', start);
     } else {
         start();
+    }
+})();
+
+/* === Outbox queue card === */
+(function () {
+    const apiBase = window.APP_CONFIG?.apiBaseUrl ?? '/api';
+    let currentStatus = 'pending';
+
+    function init() {
+        const card = document.getElementById('outbox-queue-card');
+        if (!card) return;
+
+        card.querySelectorAll('#outbox-status-tabs button').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                card.querySelectorAll('#outbox-status-tabs button').forEach((b) => b.classList.remove('active'));
+                btn.classList.add('active');
+                currentStatus = btn.dataset.status;
+                refresh();
+            });
+        });
+        document.getElementById('outbox-refresh-btn').addEventListener('click', refresh);
+        document.getElementById('outbox-clear-btn').addEventListener('click', clearAll);
+
+        refresh();
+    }
+
+    async function refresh() {
+        const tbody = document.getElementById('outbox-queue-tbody');
+        tbody.innerHTML = '<tr><td colspan="10" class="text-center text-muted py-3 small">Loading&hellip;</td></tr>';
+
+        try {
+            const data = await Dashboard.apiRequest(`/notifications/outbox?status=${encodeURIComponent(currentStatus)}&limit=100`);
+            const items = data?.items ?? [];
+            renderRows(items);
+            updateClearButton();
+            document.getElementById('outbox-row-count').textContent = items.length === 0 ? '' : `${items.length} row${items.length === 1 ? '' : 's'}`;
+        } catch (err) {
+            tbody.innerHTML = `<tr><td colspan="10" class="text-center text-danger small py-3">${Dashboard.escapeHtml(err?.message ?? 'Failed to load outbox')}</td></tr>`;
+        }
+    }
+
+    function renderRows(items) {
+        const tbody = document.getElementById('outbox-queue-tbody');
+        tbody.replaceChildren();
+
+        if (items.length === 0) {
+            const tr = document.createElement('tr');
+            const td = document.createElement('td');
+            td.colSpan = 10;
+            td.className = 'text-center text-muted py-3 small';
+            td.textContent = 'No rows';
+            tr.appendChild(td);
+            tbody.appendChild(tr);
+            return;
+        }
+
+        items.forEach((row) => tbody.appendChild(buildRow(row)));
+    }
+
+    function buildRow(row) {
+        const tr = document.createElement('tr');
+        tr.dataset.id = row.id;
+
+        appendText(tr, '#' + row.id);
+        appendStatus(tr, row.status);
+        appendText(tr, row.channel_name ?? `#${row.channel_id}`);
+        appendText(tr, row.call_number ?? `#${row.db_call_id}`);
+        appendText(tr, row.intent);
+        appendText(tr, String(row.attempts));
+        appendText(tr, row.next_attempt_at ? Dashboard.formatTime(row.next_attempt_at) : '—');
+        appendError(tr, row.last_error);
+        appendText(tr, Dashboard.formatTime(row.updated_at));
+        appendActions(tr, row);
+
+        return tr;
+    }
+
+    function appendText(tr, text) {
+        const td = document.createElement('td');
+        td.textContent = text;
+        tr.appendChild(td);
+    }
+
+    function appendStatus(tr, status) {
+        const td = document.createElement('td');
+        const span = document.createElement('span');
+        span.className = `outbox-status-pill ${status}`;
+        span.textContent = status;
+        td.appendChild(span);
+        tr.appendChild(td);
+    }
+
+    function appendError(tr, err) {
+        const td = document.createElement('td');
+        td.className = 'error-cell';
+        if (err) {
+            td.title = err;
+            td.textContent = err;
+        } else {
+            td.textContent = '—';
+        }
+        tr.appendChild(td);
+    }
+
+    function appendActions(tr, row) {
+        const td = document.createElement('td');
+        td.className = 'text-end';
+
+        if (row.status === 'failed') {
+            const retryBtn = document.createElement('button');
+            retryBtn.type = 'button';
+            retryBtn.className = 'btn btn-sm btn-outline-primary me-1';
+            retryBtn.innerHTML = '<i class="bi bi-arrow-clockwise"></i> Retry';
+            retryBtn.addEventListener('click', () => retryRow(row.id));
+            td.appendChild(retryBtn);
+        }
+
+        const dismissBtn = document.createElement('button');
+        dismissBtn.type = 'button';
+        dismissBtn.className = 'btn btn-sm btn-outline-secondary';
+        dismissBtn.innerHTML = '<i class="bi bi-x-lg"></i>';
+        dismissBtn.title = 'Dismiss this row';
+        dismissBtn.addEventListener('click', () => dismissRow(row.id));
+        td.appendChild(dismissBtn);
+
+        tr.appendChild(td);
+    }
+
+    async function retryRow(id) {
+        try {
+            await Dashboard.apiRequest(`/notifications/outbox/${id}/retry`, { method: 'POST' });
+            refresh();
+        } catch (err) {
+            alert('Retry failed: ' + (err?.message ?? 'unknown'));
+        }
+    }
+
+    async function dismissRow(id) {
+        if (!confirm(`Dismiss outbox row #${id}?`)) return;
+        try {
+            await Dashboard.apiRequest(`/notifications/outbox/${id}`, { method: 'DELETE' });
+            refresh();
+        } catch (err) {
+            alert('Dismiss failed: ' + (err?.message ?? 'unknown'));
+        }
+    }
+
+    function updateClearButton() {
+        const btn = document.getElementById('outbox-clear-btn');
+        const label = document.getElementById('outbox-clear-status-label');
+        if (currentStatus === 'done' || currentStatus === 'failed') {
+            label.textContent = currentStatus;
+            btn.hidden = false;
+        } else {
+            btn.hidden = true;
+        }
+    }
+
+    async function clearAll() {
+        if (currentStatus !== 'done' && currentStatus !== 'failed') return;
+        if (!confirm(`Clear all ${currentStatus} outbox rows?`)) return;
+        try {
+            const data = await Dashboard.apiRequest(
+                `/notifications/outbox/clear?status=${encodeURIComponent(currentStatus)}`,
+                { method: 'POST' },
+            );
+            const deleted = data?.deleted ?? 0;
+            alert(`${deleted} row${deleted === 1 ? '' : 's'} deleted.`);
+            refresh();
+        } catch (err) {
+            alert('Clear failed: ' + (err?.message ?? 'unknown'));
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
     }
 })();
 </script>

--- a/src/Notifications/Outbox/OutboxRepository.php
+++ b/src/Notifications/Outbox/OutboxRepository.php
@@ -182,4 +182,74 @@ final class OutboxRepository implements OutboxRepositoryInterface
             $stmt->execute([$attempts, $errorMessage, $rowId]);
         });
     }
+
+    private const KNOWN_STATUSES = ['pending', 'in_flight', 'done', 'failed'];
+
+    public function listByStatus(string $status, int $limit): array
+    {
+        return $this->exec(function (PDO $db) use ($status, $limit): array {
+            $sql = "SELECT o.id, o.db_call_id, o.channel_id, o.intent, o.resend_all,
+                           o.status, o.attempts, o.next_attempt_at, o.claimed_at,
+                           o.claimed_by, o.last_error, o.created_at, o.updated_at,
+                           nc.name AS channel_name, nc.type AS channel_type,
+                           c.call_number
+                    FROM notification_outbox o
+                    LEFT JOIN notification_channels nc ON nc.id = o.channel_id
+                    LEFT JOIN calls c ON c.id = o.db_call_id";
+            $params = [];
+            if ($status !== 'all') {
+                if (! in_array($status, self::KNOWN_STATUSES, true)) {
+                    return [];
+                }
+                $sql .= " WHERE o.status = ?";
+                $params[] = $status;
+            }
+            $sql .= " ORDER BY o.id DESC LIMIT ?";
+            $stmt = $db->prepare($sql);
+            $i = 1;
+            foreach ($params as $p) {
+                $stmt->bindValue($i++, $p);
+            }
+            $stmt->bindValue($i, $limit, PDO::PARAM_INT);
+            $stmt->execute();
+            return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+        });
+    }
+
+    public function retry(int $rowId): bool
+    {
+        return $this->exec(function (PDO $db) use ($rowId): bool {
+            $stmt = $db->prepare(
+                "UPDATE notification_outbox
+                 SET status = 'pending', attempts = 0,
+                     next_attempt_at = NULL, last_error = NULL,
+                     claimed_at = NULL, claimed_by = NULL,
+                     updated_at = CURRENT_TIMESTAMP
+                 WHERE id = ?"
+            );
+            $stmt->execute([$rowId]);
+            return $stmt->rowCount() > 0;
+        });
+    }
+
+    public function delete(int $rowId): bool
+    {
+        return $this->exec(function (PDO $db) use ($rowId): bool {
+            $stmt = $db->prepare("DELETE FROM notification_outbox WHERE id = ?");
+            $stmt->execute([$rowId]);
+            return $stmt->rowCount() > 0;
+        });
+    }
+
+    public function deleteByStatus(string $status): int
+    {
+        if (! in_array($status, self::KNOWN_STATUSES, true)) {
+            return 0;
+        }
+        return $this->exec(function (PDO $db) use ($status): int {
+            $stmt = $db->prepare("DELETE FROM notification_outbox WHERE status = ?");
+            $stmt->execute([$status]);
+            return $stmt->rowCount();
+        });
+    }
 }

--- a/src/Notifications/Outbox/OutboxRepositoryInterface.php
+++ b/src/Notifications/Outbox/OutboxRepositoryInterface.php
@@ -44,4 +44,25 @@ interface OutboxRepositoryInterface
     ): void;
 
     public function markFailed(int $rowId, int $attempts, string $errorMessage): void;
+
+    /**
+     * List rows for operator inspection, joined with channel name/type and
+     * call_number for display.
+     *
+     * @param string $status One of `pending`, `in_flight`, `done`, `failed`, `all`.
+     * @return array<int,array<string,mixed>>
+     */
+    public function listByStatus(string $status, int $limit): array;
+
+    /**
+     * Operator-initiated retry: reset a failed (or any) row to pending with
+     * cleared backoff state. Returns true if a row was updated.
+     */
+    public function retry(int $rowId): bool;
+
+    /** Operator-initiated dismissal of a single row. Returns true if removed. */
+    public function delete(int $rowId): bool;
+
+    /** Bulk delete by status. Returns count removed. */
+    public function deleteByStatus(string $status): int;
 }

--- a/tests/Integration/Notifications/OutboxRepositoryTest.php
+++ b/tests/Integration/Notifications/OutboxRepositoryTest.php
@@ -205,6 +205,112 @@ final class OutboxRepositoryTest extends TestCase
         $this->assertSame([], $claimed);
     }
 
+    public function testListByStatusReturnsPendingWithChannelJoin(): void
+    {
+        $pending = $this->insertPending();
+        $done    = $this->insertPending();
+        $this->repo->markDone($done);
+
+        $rows = $this->repo->listByStatus('pending', 50);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame($pending, (int) $rows[0]['id']);
+        $this->assertSame('ntfy_primary', $rows[0]['channel_name']);
+        $this->assertSame('ntfy', $rows[0]['channel_type']);
+        $this->assertSame('C-1', $rows[0]['call_number']);
+    }
+
+    public function testListByStatusFailedFiltersCorrectly(): void
+    {
+        $pending = $this->insertPending();
+        $failed  = $this->insertPending();
+        $this->repo->markFailed($failed, 5, 'retries exhausted');
+
+        $rows = $this->repo->listByStatus('failed', 50);
+        $this->assertCount(1, $rows);
+        $this->assertSame($failed, (int) $rows[0]['id']);
+        $this->assertSame('retries exhausted', $rows[0]['last_error']);
+    }
+
+    public function testListByStatusAllReturnsEverything(): void
+    {
+        $this->insertPending();
+        $done = $this->insertPending();
+        $this->repo->markDone($done);
+
+        $rows = $this->repo->listByStatus('all', 50);
+        $this->assertCount(2, $rows);
+    }
+
+    public function testListByStatusHonorsLimit(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->insertPending();
+        }
+        $rows = $this->repo->listByStatus('pending', 2);
+        $this->assertCount(2, $rows);
+    }
+
+    public function testListByStatusOrdersByIdDesc(): void
+    {
+        $first  = $this->insertPending();
+        $second = $this->insertPending();
+        $third  = $this->insertPending();
+
+        $rows = $this->repo->listByStatus('pending', 50);
+        $ids  = array_map(static fn ($r) => (int) $r['id'], $rows);
+        $this->assertSame([$third, $second, $first], $ids);
+    }
+
+    public function testRetryClearsFailedRowToPending(): void
+    {
+        $id = $this->insertPending();
+        $this->repo->markFailed($id, 5, 'retries exhausted');
+
+        $ok = $this->repo->retry($id);
+        $this->assertTrue($ok);
+
+        $row = self::$db->query("SELECT status, attempts, next_attempt_at, last_error FROM notification_outbox WHERE id={$id}")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('pending', $row['status']);
+        $this->assertSame(0, (int) $row['attempts']);
+        $this->assertNull($row['next_attempt_at']);
+        $this->assertNull($row['last_error']);
+    }
+
+    public function testRetryReturnsFalseForMissingRow(): void
+    {
+        $this->assertFalse($this->repo->retry(99999));
+    }
+
+    public function testDeleteRemovesRow(): void
+    {
+        $id = $this->insertPending();
+        $ok = $this->repo->delete($id);
+        $this->assertTrue($ok);
+        $count = (int) self::$db->query("SELECT COUNT(*) FROM notification_outbox WHERE id={$id}")->fetchColumn();
+        $this->assertSame(0, $count);
+    }
+
+    public function testDeleteReturnsFalseForMissingRow(): void
+    {
+        $this->assertFalse($this->repo->delete(99999));
+    }
+
+    public function testDeleteByStatusBulkDeletes(): void
+    {
+        $d1 = $this->insertPending();
+        $d2 = $this->insertPending();
+        $pending = $this->insertPending();
+        $this->repo->markDone($d1);
+        $this->repo->markDone($d2);
+
+        $deleted = $this->repo->deleteByStatus('done');
+        $this->assertSame(2, $deleted);
+        $remaining = (int) self::$db->query("SELECT COUNT(*) FROM notification_outbox")->fetchColumn();
+        $this->assertSame(1, $remaining);
+    }
+
     private function insertPending(): int
     {
         return $this->repo->insert(

--- a/tests/Integration/OutboxControllerTest.php
+++ b/tests/Integration/OutboxControllerTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Integration;
+
+use DateTimeImmutable;
+use NwsCad\Api\Controllers\OutboxController;
+use NwsCad\Api\Response;
+use NwsCad\Database;
+use NwsCad\Notifications\Events\Intent;
+use NwsCad\Notifications\Outbox\OutboxRepository;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \NwsCad\Api\Controllers\OutboxController
+ * @uses \NwsCad\Api\Response
+ * @uses \NwsCad\Database
+ * @uses \NwsCad\Config
+ * @uses \NwsCad\Logger
+ * @uses \NwsCad\Logging\RedactingProcessor
+ * @uses \NwsCad\Logging\SecretRegistry
+ * @uses \NwsCad\Notifications\Outbox\OutboxRepository
+ * @uses \NwsCad\Notifications\Events\Intent
+ */
+class OutboxControllerTest extends TestCase
+{
+    private static PDO $db;
+    private OutboxRepository $repo;
+    private int $callId;
+    private int $channelId;
+
+    public static function setUpBeforeClass(): void
+    {
+        try {
+            self::$db = Database::getConnection();
+        } catch (\Throwable $e) {
+            self::markTestSkipped('Database not available');
+        }
+    }
+
+    protected function setUp(): void
+    {
+        cleanTestDatabase();
+        Response::resetForTesting();
+        $this->repo = new OutboxRepository(self::$db);
+
+        self::$db->exec("INSERT INTO calls (call_id, call_number, create_datetime) VALUES (1, 'C-1', '2026-05-07 12:00:00')");
+        $this->callId = (int) self::$db->lastInsertId();
+
+        self::$db->exec("INSERT INTO notification_channels (name, type, enabled, base_url, config_json) VALUES ('ntfy_primary', 'ntfy', 1, 'https://x', '{}')");
+        $this->channelId = (int) self::$db->lastInsertId();
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = [];
+        $_POST = [];
+    }
+
+    private function insertPending(): int
+    {
+        return $this->repo->insert(
+            callId:         $this->callId,
+            channelId:      $this->channelId,
+            intent:         Intent::Created,
+            resendAll:      true,
+            addedTopics:    [],
+            createDateTime: new DateTimeImmutable('2026-05-07 12:00:00'),
+        );
+    }
+
+    public function testIndexReturnsPendingByDefault(): void
+    {
+        $id = $this->insertPending();
+
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->index();
+        $payload = json_decode((string) ob_get_clean(), true);
+
+        $this->assertTrue($payload['success']);
+        $this->assertSame('pending', $payload['data']['status']);
+        $this->assertCount(1, $payload['data']['items']);
+        $this->assertSame($id, (int) $payload['data']['items'][0]['id']);
+        $this->assertSame('ntfy_primary', $payload['data']['items'][0]['channel_name']);
+    }
+
+    public function testIndexHonorsStatusFilter(): void
+    {
+        $pending = $this->insertPending();
+        $failed  = $this->insertPending();
+        $this->repo->markFailed($failed, 5, 'retries exhausted');
+
+        $_GET['status'] = 'failed';
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->index();
+        $payload = json_decode((string) ob_get_clean(), true);
+
+        $this->assertTrue($payload['success']);
+        $this->assertCount(1, $payload['data']['items']);
+        $this->assertSame($failed, (int) $payload['data']['items'][0]['id']);
+    }
+
+    public function testIndexRejectsUnknownStatus(): void
+    {
+        $_GET['status'] = 'bogus';
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->index();
+        $payload = json_decode((string) ob_get_clean(), true);
+
+        $this->assertFalse($payload['success']);
+        $this->assertSame(400, http_response_code());
+        $this->assertContains('pending', $payload['errors']['allowed_statuses']);
+    }
+
+    public function testIndexClampsLimit(): void
+    {
+        for ($i = 0; $i < 3; $i++) {
+            $this->insertPending();
+        }
+        $_GET['limit'] = '99999';
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->index();
+        $payload = json_decode((string) ob_get_clean(), true);
+        $this->assertTrue($payload['success']);
+        $this->assertSame(200, (int) $payload['data']['limit']);
+    }
+
+    public function testRetryResetsRowToPending(): void
+    {
+        $id = $this->insertPending();
+        $this->repo->markFailed($id, 5, 'retries exhausted');
+
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->retry((string) $id);
+        $payload = json_decode((string) ob_get_clean(), true);
+
+        $this->assertTrue($payload['success']);
+        $this->assertSame($id, (int) $payload['data']['id']);
+
+        $row = self::$db->query("SELECT status, attempts FROM notification_outbox WHERE id={$id}")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('pending', $row['status']);
+        $this->assertSame(0, (int) $row['attempts']);
+    }
+
+    public function testRetryReturns400ForNonNumericId(): void
+    {
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->retry('not-a-number');
+        $payload = json_decode((string) ob_get_clean(), true);
+        $this->assertFalse($payload['success']);
+        $this->assertSame(400, http_response_code());
+    }
+
+    public function testRetryReturns404ForMissingId(): void
+    {
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->retry('99999');
+        $payload = json_decode((string) ob_get_clean(), true);
+        $this->assertFalse($payload['success']);
+        $this->assertSame(404, http_response_code());
+    }
+
+    public function testDismissDeletesRow(): void
+    {
+        $id = $this->insertPending();
+
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->dismiss((string) $id);
+        $payload = json_decode((string) ob_get_clean(), true);
+
+        $this->assertTrue($payload['success']);
+        $remaining = (int) self::$db->query("SELECT COUNT(*) FROM notification_outbox WHERE id={$id}")->fetchColumn();
+        $this->assertSame(0, $remaining);
+    }
+
+    public function testDismissReturns404ForMissingId(): void
+    {
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->dismiss('99999');
+        $payload = json_decode((string) ob_get_clean(), true);
+        $this->assertFalse($payload['success']);
+        $this->assertSame(404, http_response_code());
+    }
+
+    public function testClearDoneBulkDeletes(): void
+    {
+        $d1 = $this->insertPending();
+        $d2 = $this->insertPending();
+        $pending = $this->insertPending();
+        $this->repo->markDone($d1);
+        $this->repo->markDone($d2);
+
+        $_GET['status'] = 'done';
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->clear();
+        $payload = json_decode((string) ob_get_clean(), true);
+
+        $this->assertTrue($payload['success']);
+        $this->assertSame(2, $payload['data']['deleted']);
+        $remaining = (int) self::$db->query("SELECT COUNT(*) FROM notification_outbox")->fetchColumn();
+        $this->assertSame(1, $remaining);
+    }
+
+    public function testClearRejectsBulkClearForPendingStatus(): void
+    {
+        $_GET['status'] = 'pending';
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->clear();
+        $payload = json_decode((string) ob_get_clean(), true);
+        $this->assertFalse($payload['success']);
+        $this->assertSame(400, http_response_code());
+    }
+}


### PR DESCRIPTION
## Summary
Phase-2 surface for the notification outbox (extends PR #26). Adds operator-facing read + write endpoints plus a Bootstrap card on the notifications dashboard so failed/pending rows are visible and recoverable without SQL.

### API (4 new endpoints under `/api/notifications/outbox`)
- `GET /api/notifications/outbox?status=pending|in_flight|done|failed|all&limit=N` — list rows with channel name/type and call_number joined for display
- `POST /api/notifications/outbox/{id}/retry` — reset a row to `pending` with cleared backoff state (use on `failed` rows after fixing root cause)
- `DELETE /api/notifications/outbox/{id}` — dismiss a single row
- `POST /api/notifications/outbox/clear?status=done|failed` — bulk delete by status (restricted to `done`/`failed` so operators can't mass-delete pending or in-flight work)

### Repository
- `OutboxRepository::listByStatus(status, limit)` — LEFT JOINs `notification_channels` and `calls`
- `OutboxRepository::retry(rowId)` — `status=pending, attempts=0, next_attempt_at=NULL, last_error=NULL`
- `OutboxRepository::delete(rowId)`
- `OutboxRepository::deleteByStatus(status)` — guarded by `KNOWN_STATUSES`

### Dashboard
- New "Outbox queue" card on `notifications.php` with 5 status pills, refresh button, conditional "Clear all <status>" button for `done`/`failed`
- Per-row "Retry" (only on `failed`) and "Dismiss" buttons
- Status pills color-coded; last_error truncated with full text in `title` tooltip
- Vanilla JS in a second IIFE in the existing view; reuses `Dashboard.apiRequest` / `Dashboard.escapeHtml` / `Dashboard.formatTime`

## Test plan
- [x] 9 new `OutboxRepository` integration tests (real DB)
- [x] 11 new `OutboxController` integration tests (covers all status codes — 200/400/404)
- [x] Smoke tested via curl through the API and verified the dashboard renders all elements
- [x] Full local suite: 483 tests, 3 skipped, 0 failures
- [ ] CI Tests workflow on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)