### PR TITLE
refactor(search): inline allowedQueryParams; remove deprecated Request::filters

### DIFF
--- a/src/Api/Controllers/SearchController.php
+++ b/src/Api/Controllers/SearchController.php
@@ -25,6 +25,25 @@ class SearchController
     }
 
     /**
+     * Pick the allow-listed query parameters from $_GET, preserving raw values
+     * (no type coercion, no empty-string filtering — callers handle those).
+     *
+     * @param array<string> $allowed
+     * @return array<string,mixed>
+     */
+    private function allowedQueryParams(array $allowed): array
+    {
+        $out = [];
+        foreach ($allowed as $key) {
+            $value = $_GET[$key] ?? null;
+            if ($value !== null) {
+                $out[$key] = $value;
+            }
+        }
+        return $out;
+    }
+
+    /**
      * Search calls by various criteria
      * GET /api/search/calls
      */
@@ -33,7 +52,7 @@ class SearchController
         try {
             $pagination = Request::pagination();
             $search = Request::search();
-            $filters = Request::filters([
+            $filters = $this->allowedQueryParams([
                 'call_number',
                 'nature_of_call',
                 'caller_name',
@@ -275,7 +294,7 @@ class SearchController
     {
         try {
             $pagination = Request::pagination();
-            $filters = Request::filters([
+            $filters = $this->allowedQueryParams([
                 'address',
                 'city',
                 'state',
@@ -461,7 +480,7 @@ class SearchController
         try {
             $pagination = Request::pagination();
             $search = Request::search();
-            $filters = Request::filters([
+            $filters = $this->allowedQueryParams([
                 'unit_number',
                 'unit_type',
                 'jurisdiction',

--- a/src/Api/Request.php
+++ b/src/Api/Request.php
@@ -125,32 +125,6 @@ class Request
     }
 
     /**
-     * Get filter parameters
-     *
-     * @deprecated Use \NwsCad\Api\Filtering\FilterCriteria::fromQuery() instead.
-     *             Retained for SearchController which is out of scope for the
-     *             v1 filter-refactor. Remove once SearchController is migrated.
-     *
-     * Only returns values for explicitly allowed filter keys.
-     *
-     * @param array<string> $allowed List of allowed filter parameter names
-     * @return array<string, mixed> Associative array of filter key => value
-     */
-    public static function filters(array $allowed = []): array
-    {
-        $filters = [];
-        
-        foreach ($allowed as $key) {
-            $value = self::query($key);
-            if ($value !== null) {
-                $filters[$key] = $value;
-            }
-        }
-
-        return $filters;
-    }
-
-    /**
      * Get sorting parameters
      * 
      * Normalizes sort direction to uppercase ASC or DESC.

--- a/tests/Unit/ApiRequestTest.php
+++ b/tests/Unit/ApiRequestTest.php
@@ -144,18 +144,6 @@ class ApiRequestTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testFiltersReturnsOnlyAllowedParameters(): void
-    {
-        $_GET = ['status' => 'active', 'type' => 'medical', 'ignored' => 'value'];
-        
-        $filters = Request::filters(['status', 'type']);
-        
-        $this->assertIsArray($filters);
-        $this->assertArrayHasKey('status', $filters);
-        $this->assertArrayHasKey('type', $filters);
-        $this->assertArrayNotHasKey('ignored', $filters);
-    }
-
     public function testSortingReturnsDefaultValues(): void
     {
         $_GET = [];


### PR DESCRIPTION
## Summary
Completes the migration that the \`@deprecated\` note on \`Request::filters()\` called out as the remaining work:

> Use \`\NwsCad\Api\Filtering\FilterCriteria::fromQuery()\` instead. Retained for SearchController which is out of scope for the v1 filter-refactor. Remove once SearchController is migrated.

## Why a local helper instead of FilterCriteria

\`SearchController\`'s three search endpoints (\`calls\`, \`location\`, \`units\`) use LIKE-style search semantics — partial-match LIKE, composite person/personnel names, boolean-string coercion (\`'true'\`/\`'false'\` → 1/0) — that don't map onto \`FilterCriteria\`'s typed allowlist contract. The cleanest path is to move the small whitelist helper local to its only consumer rather than force it through an abstraction designed for typed filter values.

## Changes
- Add private \`SearchController::allowedQueryParams(array $allowed): array\` — preserves exact semantics of the old \`Request::filters()\` (raw values from \`$_GET\`, no type coercion, no empty-string filtering)
- Switch three call sites in \`SearchController\` to the private helper
- Delete \`Request::filters()\` from \`src/Api/Request.php\`
- Delete \`ApiRequestTest::testFiltersReturnsOnlyAllowedParameters\`

Net: -41 + 22 = -19 lines.

## Test plan
- [x] \`grep -rn 'Request::filters' --include='*.php' .\` returns no matches
- [x] \`ApiSearchTest\`: 8/8 green
- [x] \`ApiRequestTest\`: 17/17 green (was 18 — one test for the deleted method removed)
- [x] Full unit suite: 261 tests, 2 skipped, 0 failures
- [x] Smoke-tested \`/api/search/calls\` and \`/api/search/location\` via curl
- [ ] CI Tests workflow on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)