### PR TITLE
feat(security): LogsController admin allowlist gates production access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,10 @@ PHP_MEMORY_LIMIT=512M
 APP_ENV=development
 APP_DEBUG=true
 APP_LOGS_ENABLED=true
+# Admin allowlist for /api/logs endpoints in production (csv of identity-header
+# users). Empty in production = denied (fail-secure). Ignored when APP_ENV is
+# not production. Example: LOGS_ADMIN_USERS=alice,bob
+LOGS_ADMIN_USERS=
 WATCH_FOLDER=/var/www/watch
 LOG_LEVEL=debug
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ After `AegisXmlParser::processFile()` commits, it dispatches a `CallProcessedEve
 - Prepared statements only; identifier validation in `DbHelper`.
 - XXE protection: do not enable `LIBXML_NOENT` when calling SimpleXML; use `LIBXML_NONET`.
 - CORS origin whitelist lives in `Security/SecurityHeaders.php`.
-- `LogsController` is disabled by default in production — keep it that way unless explicitly toggling.
+- `LogsController` is disabled by default in production. Enabling it (`APP_LOGS_ENABLED=true`) also requires `LOGS_ADMIN_USERS` to be set to a csv allowlist of identity-header users; an empty allowlist in prod is treated as deny (fail-secure). Non-production environments remain open.
 - Coordinate inputs are validated (lat ±90, lng ±180); LIKE patterns are escaped.
 - Never `extract($row)` from DB rows. Use explicit DTO mapping (see `IncidentDto::fromRow()` for the pattern).
 - Notification secrets are referenced by **env-var name** (`auth_token_env`) in `notification_channels.config_json`, never by literal value. Read them at send time with `Config::secret($envName)`.
@@ -166,6 +166,7 @@ After `AegisXmlParser::processFile()` commits, it dispatches a `CallProcessedEve
 | `NOTIFICATION_DELTA_SECONDS` (default 900) | Delta-time gate evaluated at outbox-write time |
 | `OUTBOX_BATCH_SIZE` (default 10) | Max outbox rows claimed per FileWatcher tick |
 | `OUTBOX_MAX_ATTEMPTS` (default 5) | Permanent-failure threshold for outbox rows |
+| `LOGS_ADMIN_USERS` (csv, default empty) | Allowlist of identity-header users permitted to read `/api/logs` in production. Empty in prod = denied (fail-secure). Ignored outside prod. |
 | `STALE_OPEN_CALL_HOURS` (default 72) | Guardrail: a call open this many hours since `create_datetime` is reclassified as closed in SQL status filters, stats counts, and dashboard badges (via `is_stale` on API rows). Raw rows are not mutated. |
 | `NTFY_AUTH_TOKEN`, `NTFY_BASE_URL` | Required when an `ntfy` channel is enabled |
 | `PUSHOVER_TOKEN`, `PUSHOVER_USER`, `PUSHOVER_BASE_URL` | Required when a `pushover` channel is enabled |

--- a/src/Api/Controllers/LogsController.php
+++ b/src/Api/Controllers/LogsController.php
@@ -7,6 +7,7 @@ namespace NwsCad\Api\Controllers;
 use NwsCad\Config;
 use NwsCad\Api\Request;
 use NwsCad\Api\Response;
+use NwsCad\Security\Identity;
 use Exception;
 
 /**
@@ -18,14 +19,13 @@ use Exception;
  * sensitive information (IP addresses, usernames, error details, etc.).
  * 
  * Security measures implemented:
- * - Production environment check (disabled by default)
+ * - Production environment check (disabled by default; gate at app.logs_enabled)
+ * - Production admin allowlist (LOGS_ADMIN_USERS env; empty list = fail-secure deny)
+ * - Identity comes from the trusted-proxy + identity-header chain
  * - Directory traversal prevention
  * - Log level whitelist validation
  * - Filename format validation
- * 
- * TODO: Add proper authentication (API key, admin session, etc.) before
- * enabling in production.
- * 
+ *
  * @package NwsCad\Api\Controllers
  */
 class LogsController
@@ -52,19 +52,33 @@ class LogsController
      */
     private function checkAccess(): void
     {
-        $config = Config::getInstance();
-        $logsEnabled = $config->get('app.logs_enabled', false); // Default to disabled
-        
-        // In production, logs should be disabled unless explicitly enabled
-        if ($config->get('app.env') === 'production' && !$logsEnabled) {
-            Response::forbidden('Log access is disabled in production');
+        $config      = Config::getInstance();
+        $logsEnabled = (bool) $config->get('app.logs_enabled', false);
+        $isProd      = $config->get('app.env') === 'production';
+
+        // Non-production: open access. Dev environments deliberately make logs
+        // reachable without the admin-allowlist gate.
+        if (! $isProd) {
+            return;
         }
-        
-        // Development environments can access logs
-        // TODO: Add proper authentication here:
-        // - Check for admin API key in header
-        // - Verify admin session
-        // - Check IP whitelist
+
+        // Production with logs disabled: deny immediately.
+        if (! $logsEnabled) {
+            Response::forbidden('Log access is disabled in production');
+            return;
+        }
+
+        // Production with logs enabled: require the caller's identity to match
+        // the admin allowlist. Empty allowlist is treated as deny (fail-secure):
+        // an operator who enables logs in prod without an allowlist almost
+        // certainly didn't mean to.
+        $allowlist = (array) $config->get('logs.admin_users', []);
+        $user      = Identity::current()->user;
+
+        if ($user === null || $allowlist === [] || ! in_array($user, $allowlist, true)) {
+            Response::forbidden('Log access requires an admin identity');
+            return;
+        }
     }
     
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -78,6 +78,13 @@ class Config
                 'log_level' => $this->env('LOG_LEVEL', 'info'),
                 'logs_enabled' => $this->env('APP_LOGS_ENABLED', 'false') === 'true',
             ],
+            'logs' => [
+                // Allowlist of identity-header users permitted to read logs
+                // in production (when app.logs_enabled is true). Empty list
+                // in production = denied (fail-secure). Ignored in non-prod
+                // environments where logs are open to anyone reaching the API.
+                'admin_users' => self::csv($this->env('LOGS_ADMIN_USERS', '')),
+            ],
             'watcher' => [
                 'folder' => $this->env('WATCH_FOLDER', __DIR__ . '/../watch'),
                 'interval' => (int)$this->env('WATCHER_INTERVAL', '5'),

--- a/tests/Integration/ApiLogsTest.php
+++ b/tests/Integration/ApiLogsTest.php
@@ -16,6 +16,8 @@ use PHPUnit\Framework\TestCase;
  * @uses \NwsCad\Logger
  * @uses \NwsCad\Logging\RedactingProcessor
  * @uses \NwsCad\Logging\SecretRegistry
+ * @uses \NwsCad\Security\Identity
+ * @uses \NwsCad\Security\InputValidator
  */
 class ApiLogsTest extends TestCase
 {
@@ -188,53 +190,130 @@ EOL;
 
     public function testDeniesAccessWhenDisabled(): void
     {
-        // Disable logs. Config reads $_ENV first then falls back to getenv(),
-        // so a putenv() alone wouldn't override the phpunit.xml-supplied
-        // $_ENV['APP_ENV']='testing'. Set both.
-        $prevEnv = $_ENV['APP_ENV'] ?? null;
-        $prevLogsEnabled = $_ENV['APP_LOGS_ENABLED'] ?? null;
-        $_ENV['APP_LOGS_ENABLED'] = 'false';
-        $_ENV['APP_ENV'] = 'production';
-        putenv('APP_LOGS_ENABLED=false');
-        putenv('APP_ENV=production');
+        $this->withProdEnv(logsEnabled: false, allowlist: '', identityUser: null, scenario: function () {
+            $controller = new \NwsCad\Api\Controllers\LogsController();
+            ob_start();
+            $controller->index();
+            $data = json_decode((string) ob_get_clean(), true);
+            $this->assertIsArray($data, 'Controller should have emitted a JSON response');
+            $this->assertFalse($data['success']);
+            $this->assertStringContainsString('disabled in production', $data['error']);
+        });
+    }
 
-        // Force config reload
-        $reflection = new \ReflectionClass(Config::class);
-        $instanceProperty = $reflection->getProperty('instance');
-        $instanceProperty->setAccessible(true);
-        $instanceProperty->setValue(null, null);
+    public function testDeniesAccessInProdWithEmptyAllowlist(): void
+    {
+        $this->withProdEnv(logsEnabled: true, allowlist: '', identityUser: 'k9barry', scenario: function () {
+            $controller = new \NwsCad\Api\Controllers\LogsController();
+            ob_start();
+            $controller->index();
+            $data = json_decode((string) ob_get_clean(), true);
+            $this->assertFalse($data['success']);
+            $this->assertStringContainsString('admin identity', $data['error']);
+        });
+    }
 
-        // Response::json() in testing mode no-ops on the second call (it
-        // can't exit() like production), so the forbidden response from
-        // checkAccess() is what we want to see — even though index() will
-        // continue running and call Response::success() afterwards, the
-        // success body is silently dropped.
-        \NwsCad\Api\Response::resetForTesting();
+    public function testDeniesAccessInProdWhenUserNotInAllowlist(): void
+    {
+        $this->withProdEnv(logsEnabled: true, allowlist: 'alice,bob', identityUser: 'mallory', scenario: function () {
+            $controller = new \NwsCad\Api\Controllers\LogsController();
+            ob_start();
+            $controller->index();
+            $data = json_decode((string) ob_get_clean(), true);
+            $this->assertFalse($data['success']);
+            $this->assertStringContainsString('admin identity', $data['error']);
+        });
+    }
 
-        $controller = new \NwsCad\Api\Controllers\LogsController();
+    public function testAllowsAccessInProdWhenUserInAllowlist(): void
+    {
+        $this->withProdEnv(logsEnabled: true, allowlist: 'alice,bob,k9barry', identityUser: 'k9barry', scenario: function () {
+            $controller = new \NwsCad\Api\Controllers\LogsController();
+            ob_start();
+            $controller->index();
+            $data = json_decode((string) ob_get_clean(), true);
+            $this->assertTrue($data['success'], 'k9barry on the allowlist should pass the gate');
+            $this->assertArrayHasKey('files', $data['data']);
+        });
+    }
 
-        ob_start();
-        $controller->index();
-        $output = ob_get_clean();
+    public function testDeniesAccessInProdWhenIdentityIsUnknown(): void
+    {
+        $this->withProdEnv(logsEnabled: true, allowlist: 'alice', identityUser: null, scenario: function () {
+            $controller = new \NwsCad\Api\Controllers\LogsController();
+            ob_start();
+            $controller->index();
+            $data = json_decode((string) ob_get_clean(), true);
+            $this->assertFalse($data['success']);
+        });
+    }
 
-        $data = json_decode($output, true);
+    /**
+     * Run the given scenario with a production-mode Config singleton, the
+     * specified logs-enabled + allowlist values, and Identity::current()
+     * resolved from the provided user (or unset for "no identity").
+     * Restores env state on return.
+     */
+    private function withProdEnv(bool $logsEnabled, string $allowlist, ?string $identityUser, \Closure $scenario): void
+    {
+        $prev = [
+            'APP_ENV'           => $_ENV['APP_ENV']           ?? null,
+            'APP_LOGS_ENABLED'  => $_ENV['APP_LOGS_ENABLED']  ?? null,
+            'LOGS_ADMIN_USERS'  => $_ENV['LOGS_ADMIN_USERS']  ?? null,
+            'HTTP_X_AUTH_USER'  => $_SERVER['HTTP_X_AUTH_USER'] ?? null,
+            'identity'          => $GLOBALS['__identity']     ?? null,
+        ];
+        try {
+            $_ENV['APP_ENV']          = 'production';
+            $_ENV['APP_LOGS_ENABLED'] = $logsEnabled ? 'true' : 'false';
+            $_ENV['LOGS_ADMIN_USERS'] = $allowlist;
+            putenv('APP_ENV=production');
+            putenv('APP_LOGS_ENABLED=' . ($logsEnabled ? 'true' : 'false'));
+            putenv("LOGS_ADMIN_USERS={$allowlist}");
 
-        $this->assertIsArray($data, 'Controller should have emitted a JSON response');
-        $this->assertFalse($data['success']);
+            $this->resetConfig();
+            \NwsCad\Api\Response::resetForTesting();
 
-        // Reset for other tests
-        if ($prevEnv === null) {
-            unset($_ENV['APP_ENV']);
-        } else {
-            $_ENV['APP_ENV'] = $prevEnv;
+            if ($identityUser !== null) {
+                $_SERVER['HTTP_X_AUTH_USER'] = $identityUser;
+                $GLOBALS['__identity'] = \NwsCad\Security\Identity::extract(Config::getInstance());
+            } else {
+                unset($_SERVER['HTTP_X_AUTH_USER']);
+                $GLOBALS['__identity'] = \NwsCad\Security\Identity::extract(Config::getInstance());
+            }
+
+            $scenario();
+        } finally {
+            foreach (['APP_ENV', 'APP_LOGS_ENABLED', 'LOGS_ADMIN_USERS'] as $k) {
+                if ($prev[$k] === null) {
+                    unset($_ENV[$k]);
+                    putenv("$k");
+                } else {
+                    $_ENV[$k] = $prev[$k];
+                    putenv("$k=" . $prev[$k]);
+                }
+            }
+            if ($prev['HTTP_X_AUTH_USER'] === null) {
+                unset($_SERVER['HTTP_X_AUTH_USER']);
+            } else {
+                $_SERVER['HTTP_X_AUTH_USER'] = $prev['HTTP_X_AUTH_USER'];
+            }
+            if ($prev['identity'] === null) {
+                unset($GLOBALS['__identity']);
+            } else {
+                $GLOBALS['__identity'] = $prev['identity'];
+            }
+            $this->resetConfig();
+            putenv('APP_LOGS_ENABLED=true');
+            putenv('APP_ENV=testing');
         }
-        if ($prevLogsEnabled === null) {
-            unset($_ENV['APP_LOGS_ENABLED']);
-        } else {
-            $_ENV['APP_LOGS_ENABLED'] = $prevLogsEnabled;
-        }
-        putenv('APP_LOGS_ENABLED=true');
-        putenv('APP_ENV=testing');
-        $instanceProperty->setValue(null, null);
+    }
+
+    private function resetConfig(): void
+    {
+        $refl = new \ReflectionClass(Config::class);
+        $prop = $refl->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null, null);
     }
 }


### PR DESCRIPTION
## Summary
Resolves the long-standing TODO on \`LogsController::checkAccess()\` asking for "proper authentication" before enabling in production.

**Design:** leverage the existing trusted-proxy + identity-header chain rather than introduce a new auth mechanism. Add a fail-secure allowlist of admin users.

### Access-decision matrix

| APP_ENV | APP_LOGS_ENABLED | LOGS_ADMIN_USERS | Identity | Result |
|---|---|---|---|---|
| (any non-prod) | (any) | (any) | (any) | ✅ open (unchanged dev behavior) |
| production | false | (any) | (any) | ❌ 403 "disabled in production" (unchanged) |
| production | true | empty/unset | (any) | ❌ 403 (**new**, fail-secure) |
| production | true | non-empty | not in list | ❌ 403 |
| production | true | non-empty | in list | ✅ allowed |

The fail-secure case is deliberate: enabling logs in production without configuring an allowlist is almost certainly an operator mistake.

### Changes
- New env var \`LOGS_ADMIN_USERS\` (csv) → Config key \`logs.admin_users\`
- Refactor \`LogsController::checkAccess()\` with the 4-branch decision above
- Drop the TODO comment + the in-method "TODO: add API key / session / IP whitelist" note
- Update class docblock to describe the allowlist gate
- 5 new integration tests covering all branches
- \`.env.example\` and \`CLAUDE.md\` updated

## Test plan
- [x] \`ApiLogsTest\`: 11/11 green (4 new + 7 pre-existing)
- [x] Unit suite: 261/261 green
- [ ] CI Tests workflow on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)