### PR TITLE
feat(security): CSP nonces for inline scripts (drop script-src unsafe-inline)

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -138,7 +138,7 @@ $pageTitle = ucfirst(str_replace('-mobile', '', $page));
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     
     <!-- Custom JS -->
-    <script>
+    <script nonce="<?= htmlspecialchars(\NwsCad\Security\SecurityHeaders::nonce(), ENT_QUOTES) ?>">
         // Always use the current origin for API calls (works for local, remote, and Codespaces)
         const baseUrl = window.location.origin;
         

--- a/src/Dashboard/Views/notifications.php
+++ b/src/Dashboard/Views/notifications.php
@@ -375,7 +375,8 @@ body:has(#notifications-channels-container) > footer {
   </div>
 </div>
 
-<script>
+<?php $__cspNonce = htmlspecialchars(\NwsCad\Security\SecurityHeaders::nonce(), ENT_QUOTES); ?>
+<script nonce="<?= $__cspNonce ?>">
 (function() {
     const POLL_INTERVAL_MS = 5000;
     const KNOWN = [

--- a/src/Security/SecurityHeaders.php
+++ b/src/Security/SecurityHeaders.php
@@ -11,6 +11,34 @@ namespace NwsCad\Security;
  */
 class SecurityHeaders
 {
+    /** @var string|null Memoized per-request CSP nonce (base64) */
+    private static ?string $nonce = null;
+
+    /**
+     * Return a per-request CSP nonce. Memoized so the same value appears in
+     * both the Content-Security-Policy header and every `<script nonce="...">`
+     * tag rendered by views during this request.
+     *
+     * Format: 22 chars of url-safe base64 (16 random bytes). Long enough that
+     * an attacker can't guess it; short enough not to bloat every script tag.
+     */
+    public static function nonce(): string
+    {
+        if (self::$nonce === null) {
+            // base64 of 16 random bytes = 24 chars including `==` padding;
+            // strip padding for a shorter token. CSP accepts any non-whitespace
+            // value here — base64 is just a convenient encoding.
+            self::$nonce = rtrim(base64_encode(random_bytes(16)), '=');
+        }
+        return self::$nonce;
+    }
+
+    /** Test-only: reset the memoized nonce so the next call generates a new one. */
+    public static function resetNonceForTesting(): void
+    {
+        self::$nonce = null;
+    }
+
     /**
      * Set all recommended security headers
      *
@@ -34,23 +62,22 @@ class SecurityHeaders
     /**
      * Set Content-Security-Policy header
      *
-     * Note: Default policy includes 'unsafe-inline' and 'unsafe-eval' for compatibility
-     * with libraries like Chart.js and Leaflet.js. In production, consider:
-     * - Using nonce-based CSP for inline scripts
-     * - Migrating to external script files
-     * - Using strict-dynamic for modern browsers
+     * The default policy uses a per-request nonce for inline scripts (no
+     * 'unsafe-inline' in script-src). 'unsafe-eval' remains for compatibility
+     * with libraries like Chart.js and Leaflet.js that compile expressions at
+     * runtime. Style attribute hardening (style-src nonces or hashes) is a
+     * separate follow-up.
      *
-     * @param string|null $policy Custom CSP policy (default: permissive for dashboard compatibility)
+     * @param string|null $policy Custom CSP policy (default: nonce-based for dashboard compatibility)
      * @return void
      */
     public static function setContentSecurityPolicy(?string $policy = null): void
     {
         if ($policy === null) {
-            // Permissive policy for dashboard with CDN libraries
-            // TODO: Tighten in production with nonces or external scripts
+            $nonce  = self::nonce();
             $policy = implode('; ', [
                 "default-src 'self'",
-                "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://unpkg.com https://*.cloudflare.com",
+                "script-src 'self' 'nonce-{$nonce}' 'unsafe-eval' https://cdn.jsdelivr.net https://unpkg.com https://*.cloudflare.com",
                 "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://fonts.googleapis.com",
                 "img-src 'self' data: https://cdn.jsdelivr.net https://*.tile.openstreetmap.org",
                 "font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com",

--- a/tests/Unit/Security/SecurityHeadersTest.php
+++ b/tests/Unit/Security/SecurityHeadersTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Unit\Security;
+
+use NwsCad\Security\SecurityHeaders;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SecurityHeaders::class)]
+final class SecurityHeadersTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        SecurityHeaders::resetNonceForTesting();
+    }
+
+    protected function tearDown(): void
+    {
+        SecurityHeaders::resetNonceForTesting();
+    }
+
+    public function testNonceIsStableWithinRequest(): void
+    {
+        $first  = SecurityHeaders::nonce();
+        $second = SecurityHeaders::nonce();
+        $this->assertSame($first, $second);
+    }
+
+    public function testNonceFormatIsBase64WithoutPadding(): void
+    {
+        $nonce = SecurityHeaders::nonce();
+        // 16 random bytes → 24 chars base64 → 22 chars without `==` padding.
+        $this->assertSame(22, strlen($nonce));
+        // CSP source-list grammar forbids whitespace and a few other chars,
+        // but base64's [A-Za-z0-9+/] is all safe. We allow url-safe variants
+        // too (the encoder may swap +/ for -_ in some PHP builds), so accept
+        // both alphabets.
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9+\/_-]{22}$/', $nonce);
+    }
+
+    public function testResetGeneratesNewValue(): void
+    {
+        $first = SecurityHeaders::nonce();
+        SecurityHeaders::resetNonceForTesting();
+        $second = SecurityHeaders::nonce();
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testTwoIndependentNoncesAreUnique(): void
+    {
+        // Generate enough nonces to make a collision astronomically unlikely.
+        // With 128 bits of entropy a collision would imply we drew the same
+        // 16 random bytes twice in two PHP calls — random_bytes(16) failing
+        // open is a far bigger problem than this test could catch.
+        $values = [];
+        for ($i = 0; $i < 20; $i++) {
+            SecurityHeaders::resetNonceForTesting();
+            $values[] = SecurityHeaders::nonce();
+        }
+        $this->assertCount(20, array_unique($values));
+    }
+}


### PR DESCRIPTION
## Summary
Resolves the long-standing TODO on \`SecurityHeaders::setContentSecurityPolicy()\` asking to "tighten in production with nonces or external scripts".

### What changed

- **\`SecurityHeaders::nonce()\`** — memoized per-request base64 token from \`random_bytes(16)\`. 22 chars (16 random bytes, base64 without padding). \`resetNonceForTesting()\` bypasses the memo for unit tests.
- **CSP** — replaced \`'unsafe-inline'\` in \`script-src\` with \`'nonce-{value}'\`. \`'unsafe-eval'\` stays for Chart.js / Leaflet runtime compilation. \`style-src\` nonces are deferred (each inline \`<style>\` block needs similar treatment — separate hardening project).
- **Inline scripts** — added \`nonce=\` attribute to the two inline \`<script>\` tags in the codebase:
  - \`public/index.php\` (window.APP_CONFIG initialization)
  - \`src/Dashboard/Views/notifications.php\` (channel-card + outbox-card JS)
- All other \`<script>\` tags are \`src="..."\` externals and only need their domains allowlisted in \`script-src\` (already configured).

### Security impact

Before: any successful XSS injection (stored or reflected) could run arbitrary inline \`<script>\` because CSP allowed \`'unsafe-inline'\`. After: the browser refuses inline scripts without a matching nonce. An attacker can't predict the per-request random token, so injected inline scripts won't execute even if they land in the DOM.

## Test plan
- [x] 4 unit tests for \`SecurityHeaders::nonce()\` covering: within-request stability, format, reset semantics, uniqueness
- [x] Unit suite: 265/265 green (+4 new tests)
- [x] Smoke-tested in dev container:
  - CSP header includes \`'nonce-XYZ'\` for script-src
  - Both inline \`<script>\` tags carry the same nonce
  - Header nonce == tag nonces within one response (verified via curl)
- [ ] CI Tests workflow on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)