### PR TITLE
feat(security, notifications): style-src nonces + outbox per-row inspector

### DIFF
--- a/public/api.php
+++ b/public/api.php
@@ -101,10 +101,12 @@ $router->delete('/notifications/log/{id}',              [NotificationsController
 $router->post('/notifications/log/clear-failed',        [NotificationsController::class, 'clearFailed']);
 
 // Outbox Controller Routes (operator admin for notification_outbox queue)
-$router->get('/notifications/outbox',                [OutboxController::class, 'index']);
-$router->post('/notifications/outbox/{id}/retry',    [OutboxController::class, 'retry']);
-$router->delete('/notifications/outbox/{id}',        [OutboxController::class, 'dismiss']);
-$router->post('/notifications/outbox/clear',         [OutboxController::class, 'clear']);
+$router->get('/notifications/outbox',                  [OutboxController::class, 'index']);
+$router->get('/notifications/outbox/{id}',             [OutboxController::class, 'show']);
+$router->post('/notifications/outbox/{id}/retry',      [OutboxController::class, 'retry']);
+$router->post('/notifications/outbox/{id}/schedule',   [OutboxController::class, 'schedule']);
+$router->delete('/notifications/outbox/{id}',          [OutboxController::class, 'dismiss']);
+$router->post('/notifications/outbox/clear',           [OutboxController::class, 'clear']);
 
 // Logs Controller Routes
 $router->get('/logs', [LogsController::class, 'index']);

--- a/public/assets/css/dashboard.css
+++ b/public/assets/css/dashboard.css
@@ -748,3 +748,26 @@ Timestamp: Wed Jan 28 01:35:28 UTC 2026
     0%   { background-color: #fef9c3; }
     100% { background-color: transparent; }
 }
+
+/* Replacements for inline style="..." attributes (style-src CSP hardening) */
+.stat-title-compact    { font-size: 1.2rem; }
+.stat-title-compact-sm { font-size: 0.9rem; }
+
+/* Width helpers for recent-calls table headers */
+.col-w-9  { width: 9%; }
+.col-w-10 { width: 10%; }
+.col-w-13 { width: 13%; }
+.col-w-19 { width: 19%; }
+.col-w-20 { width: 20%; }
+
+/* Modal map sizing — was inline style="height: 600px; width: 100%;" */
+#modal-map { height: 600px; width: 100%; }
+
+/* Floating info card overlaid on the modal map */
+.map-info-overlay {
+    bottom: 20px;
+    left: 20px;
+    max-width: 350px;
+    z-index: 1000;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}

--- a/public/assets/css/dashboard.css
+++ b/public/assets/css/dashboard.css
@@ -233,6 +233,30 @@ body:has(.dashboard-row-fill) > footer {
     margin-right: 0.25rem;
 }
 
+/* Map markers — class-based so CSP style-src can drop 'unsafe-inline'.
+   Leaflet's L.divIcon wraps html in a div with className 'custom-marker'. */
+.custom-marker .marker-circle {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    border: 3px solid #fff;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.custom-marker .marker-circle i {
+    color: #fff;
+    font-size: 14px;
+}
+
+.custom-marker .marker-circle--red    { background-color: #dc3545; }
+.custom-marker .marker-circle--yellow { background-color: #ffc107; }
+.custom-marker .marker-circle--blue   { background-color: #0dcaf0; }
+.custom-marker .marker-circle--green  { background-color: #198754; }
+.custom-marker .marker-circle--gray   { background-color: #6c757d; }
+
 /* Recent Calls List */
 .recent-call-item {
     padding: 1rem;

--- a/public/assets/css/mobile.css
+++ b/public/assets/css/mobile.css
@@ -498,3 +498,10 @@ body.mobile-view {
     animation: pulse 2s infinite;
     color: #198754 !important;
 }
+
+/* Mobile map popup — class-based so CSP style-src can drop 'unsafe-inline'. */
+.mobile-map-popup            { min-width: 200px; }
+.mobile-map-popup .popup-call-type   { font-size: 1rem; }
+.mobile-map-popup .popup-call-number { color: #6c757d; }
+.mobile-map-popup .popup-location    { margin: 8px 0; }
+.mobile-map-popup .popup-status      { margin-bottom: 8px; }

--- a/public/assets/css/notifications.css
+++ b/public/assets/css/notifications.css
@@ -1,0 +1,257 @@
+/* === Notifications page polish (banner/live-pill come from dashboard.css) === */
+
+/* Lock the notifications page to exactly one viewport tall so the
+   channel cards fill all available space without overflowing.
+   - min-height: 100vh on body alone wasn't enough: it's only a floor,
+     so the cards' natural content (10 log entries each) pushed body
+     past 100vh and forced a scrollbar.
+   - The footer's page-default .mt-5 and main's .py-4 bottom padding
+     use !important (Bootstrap utilities), so the overrides do too. */
+@media (min-width: 768px) {
+    body:has(#notifications-channels-container) {
+        height: 100vh;
+        overflow: hidden;
+    }
+}
+body:has(#notifications-channels-container) {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+body:has(#notifications-channels-container) > main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    padding-bottom: 0 !important;
+}
+body:has(#notifications-channels-container) > footer {
+    margin-top: 0 !important;
+}
+#notifications-channels-container {
+    flex: 1;
+    align-items: stretch;
+    min-height: 0;
+}
+/* Bootstrap rows are flex-wrap: wrap; with a single line, the wrap'd line's
+   cross-axis size collapses to its tallest item rather than stretching to
+   the row's full height (per CSS Align spec). Switch to nowrap above sm
+   where the two cols sit side-by-side so .channel-card can stretch. */
+@media (min-width: 768px) {
+    #notifications-channels-container { flex-wrap: nowrap; }
+}
+#notifications-channels-container > [class*="col-"] {
+    display: flex;
+}
+
+/* Channel cards — gradient header strip mirrors the dashboard's stat cards */
+.channel-card {
+    border: none;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+.channel-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
+}
+.channel-card .card-header {
+    border-bottom: none;
+    padding: 0.65rem 0.95rem;
+    color: #fff;
+    background: linear-gradient(135deg, #475569, #1e293b);
+}
+.channel-card .card-body {
+    padding: 0.75rem 0.95rem;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+.channel-card[data-type="ntfy"] .card-header {
+    background: linear-gradient(135deg, #2563eb, #4f46e5);
+}
+.channel-card[data-type="pushover"] .card-header {
+    background: linear-gradient(135deg, #db2777, #c026d3);
+}
+.channel-card .channel-type {
+    background: rgba(255,255,255,0.25) !important;
+    color: #fff;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.65rem;
+}
+.channel-card .form-check-input {
+    cursor: pointer;
+}
+.channel-card.is-disabled .card-header {
+    background: linear-gradient(135deg, #94a3b8, #64748b);
+}
+
+.channel-state-badge {
+    display: inline-block;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.channel-state-badge.is-on  { background: #d1fae5; color: #065f46; }
+.channel-state-badge.is-off { background: #e2e8f0; color: #475569; }
+
+/* Log entries — flex-grow inside the card body and scroll internally */
+.channel-log {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+}
+.channel-log .list-group-item {
+    border-left: 4px solid transparent;
+    padding: 0.5rem 0.65rem;
+    transition: background 0.15s ease;
+}
+.channel-log .list-group-item.row-success {
+    border-left-color: #10b981;
+    background: linear-gradient(90deg, #ecfdf5, transparent 60%);
+}
+.channel-log .list-group-item.row-failed {
+    border-left-color: #ef4444;
+    background: linear-gradient(90deg, #fef2f2, transparent 60%);
+}
+.channel-log .list-group-item.row-new {
+    animation: notif-flash 1.2s ease;
+}
+@keyframes notif-flash {
+    0%   { background-color: #fef9c3; }
+    100% { background-color: transparent; }
+}
+.channel-log .status-icon {
+    width: 1.4rem; height: 1.4rem;
+    border-radius: 50%;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 0.75rem;
+    color: #fff;
+    flex-shrink: 0;
+}
+.channel-log .status-icon.ok   { background: #10b981; }
+.channel-log .status-icon.fail { background: #ef4444; }
+.channel-log .http-pill {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.7rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 0.35rem;
+    background: #f1f5f9;
+    color: #475569;
+}
+.channel-log .http-pill.ok   { background: #d1fae5; color: #065f46; }
+.channel-log .http-pill.fail { background: #fee2e2; color: #991b1b; }
+
+.channel-log .dismiss-btn {
+    border: none;
+    background: transparent;
+    color: #94a3b8;
+    padding: 0.15rem 0.4rem;
+    border-radius: 0.35rem;
+    line-height: 1;
+}
+.channel-log .dismiss-btn:hover { color: #ef4444; background: #fee2e2; }
+
+.channel-error {
+    background: #fef2f2;
+    border-left: 3px solid #ef4444;
+    border-radius: 0.35rem;
+    padding: 0.5rem 0.75rem;
+    color: #991b1b;
+}
+
+.clear-failed-btn { font-size: 0.75rem; }
+
+/* Outbox queue card */
+#outbox-queue-card {
+    margin-top: 1rem;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+}
+#outbox-queue-card .card-header {
+    background: #f8fafc;
+    border-bottom: 1px solid #e2e8f0;
+}
+#outbox-queue-table {
+    font-size: 0.85rem;
+}
+#outbox-queue-table th {
+    font-weight: 600;
+    color: #475569;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+}
+#outbox-queue-table td.error-cell {
+    max-width: 24em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    font-size: 0.75rem;
+    color: #991b1b;
+}
+#outbox-queue-table tbody tr.is-inspectable {
+    cursor: pointer;
+}
+#outbox-queue-table tbody tr.is-inspectable:hover {
+    background: #f8fafc;
+}
+.outbox-status-pill {
+    display: inline-block;
+    font-size: 0.7rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+.outbox-status-pill.pending   { background: #fef3c7; color: #92400e; }
+.outbox-status-pill.in_flight { background: #dbeafe; color: #1e40af; }
+.outbox-status-pill.done      { background: #dcfce7; color: #166534; }
+.outbox-status-pill.failed    { background: #fee2e2; color: #991b1b; }
+
+/* Outbox inspector modal — per-row error detail + send history */
+#outbox-inspector-modal .modal-dialog { max-width: 720px; }
+#outbox-inspector-modal .inspector-summary dt {
+    font-weight: 600;
+    color: #475569;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+}
+#outbox-inspector-modal .inspector-error {
+    background: #fef2f2;
+    border-left: 3px solid #ef4444;
+    border-radius: 0.35rem;
+    padding: 0.5rem 0.75rem;
+    color: #991b1b;
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    font-size: 0.8rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+#outbox-inspector-modal .history-table {
+    font-size: 0.8rem;
+}
+#outbox-inspector-modal .history-table td.history-error {
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    color: #991b1b;
+    max-width: 18em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+#outbox-inspector-modal .schedule-feedback {
+    min-height: 1.2em;
+    font-size: 0.8rem;
+}

--- a/public/assets/js/dashboard-main.js
+++ b/public/assets/js/dashboard-main.js
@@ -481,7 +481,7 @@
             // when there's just one (or none), we still want the result count
             // visible to the user, so show the container whenever there are
             // results at all.
-            container.style.display = total > 0 ? 'flex' : 'none';
+            container.classList.toggle('d-none', total <= 0);
         }
         
         /**

--- a/public/assets/js/dashboard-main.js
+++ b/public/assets/js/dashboard-main.js
@@ -1395,9 +1395,14 @@ window.zoomToCallOnMap = async function(callId, latitude, longitude) {
     }
     
     try {
-        // Store call ID globally for "View Full Details" button
-        window.currentModalCallId = callId;
-        
+        // Bind the call id onto the "View Full Details" button so the maps.js
+        // [data-popup-action="view-call"] click delegator can pick it up. Inline
+        // onclick handlers aren't allowed under the current CSP.
+        const viewDetailsBtn = document.getElementById('map-modal-view-details-btn');
+        if (viewDetailsBtn) {
+            viewDetailsBtn.dataset.callId = String(callId);
+        }
+
         // Fetch call details
         console.log('[Dashboard Main] Fetching call details...');
         const call = await Dashboard.apiRequest(`/calls/${callId}`);
@@ -1495,7 +1500,9 @@ window.zoomToCallOnMap = async function(callId, latitude, longitude) {
         // Cleanup when modal is hidden
         modalEl.addEventListener('hidden.bs.modal', function() {
             console.log('[Dashboard Main] Modal hidden');
-            window.currentModalCallId = null;
+            if (viewDetailsBtn) {
+                delete viewDetailsBtn.dataset.callId;
+            }
         }, { once: true });
         
     } catch (error) {

--- a/public/assets/js/maps.js
+++ b/public/assets/js/maps.js
@@ -80,13 +80,12 @@ const MapManager = {
         
         console.log('[MapManager] Creating marker at:', lat, lon);
         
-        // Choose marker icon based on priority
-        const iconColor = this.getCallIconColor(call.priority);
+        // Choose marker color class based on priority. Styles live in dashboard.css
+        // because CSP style-src no longer allows inline style="" attributes.
+        const colorClass = this.getCallIconColorClass(call.priority);
         const icon = L.divIcon({
             className: 'custom-marker',
-            html: `<div style="background-color: ${iconColor}; width: 30px; height: 30px; border-radius: 50%; border: 3px solid white; box-shadow: 0 2px 5px rgba(0,0,0,0.3); display: flex; align-items: center; justify-content: center;">
-                <i class="bi bi-telephone-fill" style="color: white; font-size: 14px;"></i>
-            </div>`,
+            html: `<div class="marker-circle ${colorClass}"><i class="bi bi-telephone-fill"></i></div>`,
             iconSize: [30, 30],
             iconAnchor: [15, 15]
         });
@@ -100,66 +99,20 @@ const MapManager = {
     },
     
     /**
-     * Add a unit marker to the map
+     * Get call marker color class based on priority.
+     * Concrete colors live in dashboard.css under .marker-circle--{name}.
      */
-    addUnitMarker(containerId, unit) {
-        if (!this.maps[containerId]) {
-            return;
-        }
-
-        const lat = parseFloat(unit.latitude);
-        const lon = parseFloat(unit.longitude);
-
-        // Same -361 sentinel guard as addCallMarker
-        if (!Number.isFinite(lat) || !Number.isFinite(lon)
-            || lat < -90 || lat > 90 || lon < -180 || lon > 180) {
-            return;
-        }
-        
-        // Choose marker icon based on status
-        const iconColor = this.getUnitIconColor(unit.status);
-        const icon = L.divIcon({
-            className: 'custom-marker',
-            html: `<div style="background-color: ${iconColor}; width: 30px; height: 30px; border-radius: 50%; border: 3px solid white; box-shadow: 0 2px 5px rgba(0,0,0,0.3); display: flex; align-items: center; justify-content: center;">
-                <i class="bi bi-truck" style="color: white; font-size: 14px;"></i>
-            </div>`,
-            iconSize: [30, 30],
-            iconAnchor: [15, 15]
-        });
-        
-        const marker = L.marker([lat, lon], { icon })
-            .bindPopup(this.createUnitPopup(unit))
-            .addTo(this.markers[containerId]);
-        
-        return marker;
-    },
-    
-    /**
-     * Get call marker color based on priority
-     */
-    getCallIconColor(priority) {
-        const colors = {
-            1: '#dc3545', // Red - High priority
-            2: '#ffc107', // Yellow - Medium-high
-            3: '#0dcaf0', // Blue - Medium
-            4: '#198754'  // Green - Low
+    getCallIconColorClass(priority) {
+        const classes = {
+            1: 'marker-circle--red',     // High priority
+            2: 'marker-circle--yellow',  // Medium-high
+            3: 'marker-circle--blue',    // Medium
+            4: 'marker-circle--green'    // Low
         };
-        return colors[priority] || '#6c757d';
+        return classes[priority] || 'marker-circle--gray';
     },
-    
-    /**
-     * Get unit marker color based on status
-     */
-    getUnitIconColor(status) {
-        const colors = {
-            'available': '#198754',  // Green
-            'enroute': '#ffc107',    // Yellow
-            'onscene': '#dc3545',    // Red
-            'offduty': '#6c757d'     // Gray
-        };
-        return colors[status?.toLowerCase()] || '#6c757d';
-    },
-    
+
+
     /**
      * Create popup HTML for a call
      */
@@ -180,27 +133,7 @@ const MapManager = {
                     <strong>Location:</strong> ${Dashboard.escapeHtml(call.address || call.location?.address || 'N/A')}<br>
                     <strong>Time:</strong> ${Dashboard.formatTime(time)}
                 </div>
-                <button class="btn btn-sm btn-primary" onclick="viewCallDetails(${call.id || call.call_id})">
-                    View Details
-                </button>
-            </div>
-        `;
-    },
-    
-    /**
-     * Create popup HTML for a unit
-     */
-    createUnitPopup(unit) {
-        return `
-            <div class="map-popup">
-                <h6><i class="bi bi-truck"></i> ${Dashboard.escapeHtml(unit.unit_id || unit.badge_number)}</h6>
-                <div class="mb-2">
-                    <strong>Type:</strong> ${Dashboard.escapeHtml(unit.unit_type || 'N/A')}<br>
-                    <strong>Status:</strong> ${Dashboard.getStatusBadge(unit.status)}<br>
-                    <strong>Agency:</strong> ${Dashboard.escapeHtml(unit.agency || 'N/A')}<br>
-                    <strong>Current Call:</strong> ${Dashboard.escapeHtml(unit.current_call || 'None')}
-                </div>
-                <button class="btn btn-sm btn-primary" onclick="viewUnitDetails(${unit.id})">
+                <button class="btn btn-sm btn-primary" data-popup-action="view-call" data-call-id="${call.id || call.call_id}">
                     View Details
                 </button>
             </div>
@@ -261,23 +194,6 @@ const MapManager = {
     },
     
     /**
-     * Add multiple unit markers and fit map
-     */
-    showUnits(containerId, units) {
-        this.clearMarkers(containerId);
-        
-        if (!units || units.length === 0) {
-            return;
-        }
-        
-        units.forEach(unit => {
-            this.addUnitMarker(containerId, unit);
-        });
-        
-        this.fitToMarkers(containerId);
-    },
-    
-    /**
      * Resize map (useful after container size changes)
      */
     resize(containerId) {
@@ -289,3 +205,19 @@ const MapManager = {
 
 // Make globally available
 window.MapManager = MapManager;
+
+// Click delegation for popup action buttons. Leaflet popups are reattached to the
+// DOM each time they open, so binding handlers per-popup would leak listeners;
+// one document-level listener covers every popup the MapManager renders.
+// CSP no longer permits inline onclick handlers — see SecurityHeaders::setContentSecurityPolicy.
+document.addEventListener('click', (event) => {
+    const target = event.target.closest('[data-popup-action]');
+    if (!target) return;
+
+    if (target.dataset.popupAction === 'view-call') {
+        const id = parseInt(target.dataset.callId, 10);
+        if (Number.isFinite(id) && typeof window.viewCallDetails === 'function') {
+            window.viewCallDetails(id);
+        }
+    }
+});

--- a/public/assets/js/mobile.js
+++ b/public/assets/js/mobile.js
@@ -1303,18 +1303,16 @@ const MobileMaps = {
                 if (isNaN(callId)) return;
                 
                 const popupContent = `
-                    <div style="min-width: 200px;">
-                        <strong style="font-size: 1rem;">${MobileDashboard.escapeHtml(callType)}</strong><br>
-                        <small style="color: #6c757d;">#${MobileDashboard.escapeHtml(String(callNumber))}</small><br>
-                        <div style="margin: 8px 0;">
+                    <div class="mobile-map-popup">
+                        <strong class="popup-call-type">${MobileDashboard.escapeHtml(callType)}</strong><br>
+                        <small class="popup-call-number">#${MobileDashboard.escapeHtml(String(callNumber))}</small><br>
+                        <div class="popup-location">
                             <i class="bi bi-geo-alt"></i> ${MobileDashboard.escapeHtml(locationText)}
                         </div>
-                        <div style="margin-bottom: 8px;">
+                        <div class="popup-status">
                             <span class="badge ${(call.closed_flag || call.is_stale) ? 'bg-success' : 'bg-warning text-dark'}">${statusBadge}</span>
                         </div>
-                        <button 
-                            class="btn btn-primary btn-sm w-100" 
-                            onclick="MobileDashboard.openCallDetails(${callId}); return false;">
+                        <button class="btn btn-primary btn-sm w-100" data-popup-action="mobile-view-call" data-call-id="${callId}">
                             <i class="bi bi-info-circle"></i> View Details
                         </button>
                     </div>
@@ -1332,6 +1330,20 @@ const MobileMaps = {
         }
     }
 };
+
+// Click delegation for mobile map popup buttons. CSP no longer permits inline
+// onclick handlers — see SecurityHeaders::setContentSecurityPolicy. Uses a
+// distinct action name from the desktop maps.js delegator so the two stay
+// independent on pages that load both bundles.
+document.addEventListener('click', (event) => {
+    const target = event.target.closest('[data-popup-action="mobile-view-call"]');
+    if (!target) return;
+
+    const id = parseInt(target.dataset.callId, 10);
+    if (Number.isFinite(id)) {
+        MobileDashboard.openCallDetails(id);
+    }
+});
 
 // Initialize when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {

--- a/public/assets/js/mobile.js
+++ b/public/assets/js/mobile.js
@@ -154,23 +154,23 @@ const MobileDashboard = {
     showCallsList() {
         const callsView = document.getElementById('mobile-calls-view');
         const mapView = document.getElementById('mobile-map-view');
-        
-        if (callsView) callsView.style.display = 'block';
-        if (mapView) mapView.style.display = 'none';
-        
+
+        if (callsView) callsView.classList.remove('d-none');
+        if (mapView) mapView.classList.add('d-none');
+
         this.loadCallsList();
     },
-    
+
     /**
      * Show map view
      */
     showMap() {
         const callsView = document.getElementById('mobile-calls-view');
         const mapView = document.getElementById('mobile-map-view');
-        
-        if (callsView) callsView.style.display = 'none';
-        if (mapView) mapView.style.display = 'block';
-        
+
+        if (callsView) callsView.classList.add('d-none');
+        if (mapView) mapView.classList.remove('d-none');
+
         // Initialize or refresh map
         if (typeof MobileMaps !== 'undefined' && MobileMaps.initMap) {
             MobileMaps.initMap();

--- a/src/Api/Controllers/OutboxController.php
+++ b/src/Api/Controllers/OutboxController.php
@@ -64,6 +64,82 @@ final class OutboxController
         }
     }
 
+    private const HISTORY_LIMIT = 20;
+
+    /** GET /api/notifications/outbox/{id} — row detail plus send-attempt history */
+    public function show(string $id): void
+    {
+        try {
+            if (! ctype_digit($id)) {
+                Response::error('Invalid outbox id', 400);
+                return;
+            }
+            $row = $this->repo->findById((int) $id);
+            if ($row === null) {
+                Response::error('Outbox row not found', 404);
+                return;
+            }
+            $history = $this->repo->listSendHistory(
+                (int) $row['channel_id'],
+                (int) $row['db_call_id'],
+                (string) $row['intent'],
+                self::HISTORY_LIMIT,
+            );
+            Response::success(['row' => $row, 'history' => $history]);
+        } catch (Exception $e) {
+            Response::error('Failed to load outbox row: ' . $e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * POST /api/notifications/outbox/{id}/schedule
+     * Body (JSON or form): { "next_attempt_at": "YYYY-MM-DD HH:MM:SS" }
+     *
+     * Reschedules a pending or failed row to retry at the supplied time. Keeps
+     * attempts/last_error intact; failed rows transition back to pending.
+     */
+    public function schedule(string $id): void
+    {
+        try {
+            if (! ctype_digit($id)) {
+                Response::error('Invalid outbox id', 400);
+                return;
+            }
+
+            $body = json_decode((string) file_get_contents('php://input'), true);
+            $when = is_array($body) ? ($body['next_attempt_at'] ?? null) : null;
+            if (! is_string($when) || $when === '') {
+                $when = (string) ($_POST['next_attempt_at'] ?? '');
+            }
+            if (! is_string($when) || $when === '') {
+                Response::error('Missing next_attempt_at', 400);
+                return;
+            }
+
+            // Accept both 'Y-m-d H:i:s' and ISO 8601 ('Y-m-d\TH:i:s' or with timezone).
+            // DateTimeImmutable throws on invalid input → caught below.
+            $parsed = null;
+            try {
+                $parsed = new \DateTimeImmutable((string) $when);
+            } catch (\Throwable $e) {
+                Response::error('Invalid next_attempt_at: ' . $e->getMessage(), 400);
+                return;
+            }
+
+            $ok = $this->repo->reschedule((int) $id, $parsed);
+            if (! $ok) {
+                Response::error('Outbox row not found or not reschedulable (must be pending or failed)', 404);
+                return;
+            }
+            Response::success([
+                'id'              => (int) $id,
+                'next_attempt_at' => $parsed->format('Y-m-d H:i:s'),
+            ]);
+        } catch (Exception $e) {
+            Response::error('Failed to reschedule outbox row: ' . $e->getMessage(), 500);
+        }
+    }
+
     /** DELETE /api/notifications/outbox/{id} */
     public function dismiss(string $id): void
     {

--- a/src/Dashboard/Views/dashboard-mobile.php
+++ b/src/Dashboard/Views/dashboard-mobile.php
@@ -63,8 +63,8 @@
     </div>
     
     <!-- Map View (Hidden by default) -->
-    <div id="mobile-map-view" style="display: none;">
-        <div id="calls-map" style="height: calc(100vh - var(--mobile-header-height) - var(--mobile-bottom-nav-height) - 24px);"></div>
+    <div id="mobile-map-view" class="d-none">
+        <div id="calls-map"></div>
     </div>
 </div>
 

--- a/src/Dashboard/Views/notifications.php
+++ b/src/Dashboard/Views/notifications.php
@@ -4,223 +4,7 @@ declare(strict_types=1);
 
 /** @var bool $isMobile */
 ?>
-<style>
-/* === Notifications page polish (banner/live-pill come from dashboard.css) === */
-
-/* Lock the notifications page to exactly one viewport tall so the
-   channel cards fill all available space without overflowing.
-   - min-height: 100vh on body alone wasn't enough: it's only a floor,
-     so the cards' natural content (10 log entries each) pushed body
-     past 100vh and forced a scrollbar.
-   - The footer's page-default .mt-5 and main's .py-4 bottom padding
-     use !important (Bootstrap utilities), so the overrides do too. */
-@media (min-width: 768px) {
-    body:has(#notifications-channels-container) {
-        height: 100vh;
-        overflow: hidden;
-    }
-}
-body:has(#notifications-channels-container) {
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-}
-body:has(#notifications-channels-container) > main {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-    padding-bottom: 0 !important;
-}
-body:has(#notifications-channels-container) > footer {
-    margin-top: 0 !important;
-}
-#notifications-channels-container {
-    flex: 1;
-    align-items: stretch;
-    min-height: 0;
-}
-/* Bootstrap rows are flex-wrap: wrap; with a single line, the wrap'd line's
-   cross-axis size collapses to its tallest item rather than stretching to
-   the row's full height (per CSS Align spec). Switch to nowrap above sm
-   where the two cols sit side-by-side so .channel-card can stretch. */
-@media (min-width: 768px) {
-    #notifications-channels-container { flex-wrap: nowrap; }
-}
-#notifications-channels-container > [class*="col-"] {
-    display: flex;
-}
-
-/* Channel cards — gradient header strip mirrors the dashboard's stat cards */
-.channel-card {
-    border: none;
-    border-radius: 0.75rem;
-    overflow: hidden;
-    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
-    transition: transform 0.15s ease, box-shadow 0.15s ease;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-}
-.channel-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
-}
-.channel-card .card-header {
-    border-bottom: none;
-    padding: 0.65rem 0.95rem;
-    color: #fff;
-    background: linear-gradient(135deg, #475569, #1e293b);
-}
-.channel-card .card-body {
-    padding: 0.75rem 0.95rem;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-}
-.channel-card[data-type="ntfy"] .card-header {
-    background: linear-gradient(135deg, #2563eb, #4f46e5);
-}
-.channel-card[data-type="pushover"] .card-header {
-    background: linear-gradient(135deg, #db2777, #c026d3);
-}
-.channel-card .channel-type {
-    background: rgba(255,255,255,0.25) !important;
-    color: #fff;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    font-size: 0.65rem;
-}
-.channel-card .form-check-input {
-    cursor: pointer;
-}
-.channel-card.is-disabled .card-header {
-    background: linear-gradient(135deg, #94a3b8, #64748b);
-}
-
-.channel-state-badge {
-    display: inline-block;
-    padding: 0.2rem 0.55rem;
-    border-radius: 999px;
-    font-size: 0.7rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-.channel-state-badge.is-on  { background: #d1fae5; color: #065f46; }
-.channel-state-badge.is-off { background: #e2e8f0; color: #475569; }
-
-/* Log entries — flex-grow inside the card body and scroll internally */
-.channel-log {
-    flex: 1;
-    min-height: 0;
-    overflow-y: auto;
-}
-.channel-log .list-group-item {
-    border-left: 4px solid transparent;
-    padding: 0.5rem 0.65rem;
-    transition: background 0.15s ease;
-}
-.channel-log .list-group-item.row-success {
-    border-left-color: #10b981;
-    background: linear-gradient(90deg, #ecfdf5, transparent 60%);
-}
-.channel-log .list-group-item.row-failed {
-    border-left-color: #ef4444;
-    background: linear-gradient(90deg, #fef2f2, transparent 60%);
-}
-.channel-log .list-group-item.row-new {
-    animation: notif-flash 1.2s ease;
-}
-@keyframes notif-flash {
-    0%   { background-color: #fef9c3; }
-    100% { background-color: transparent; }
-}
-.channel-log .status-icon {
-    width: 1.4rem; height: 1.4rem;
-    border-radius: 50%;
-    display: inline-flex; align-items: center; justify-content: center;
-    font-size: 0.75rem;
-    color: #fff;
-    flex-shrink: 0;
-}
-.channel-log .status-icon.ok   { background: #10b981; }
-.channel-log .status-icon.fail { background: #ef4444; }
-.channel-log .http-pill {
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 0.7rem;
-    padding: 0.15rem 0.5rem;
-    border-radius: 0.35rem;
-    background: #f1f5f9;
-    color: #475569;
-}
-.channel-log .http-pill.ok   { background: #d1fae5; color: #065f46; }
-.channel-log .http-pill.fail { background: #fee2e2; color: #991b1b; }
-
-.channel-log .dismiss-btn {
-    border: none;
-    background: transparent;
-    color: #94a3b8;
-    padding: 0.15rem 0.4rem;
-    border-radius: 0.35rem;
-    line-height: 1;
-}
-.channel-log .dismiss-btn:hover { color: #ef4444; background: #fee2e2; }
-
-.channel-error {
-    background: #fef2f2;
-    border-left: 3px solid #ef4444;
-    border-radius: 0.35rem;
-    padding: 0.5rem 0.75rem;
-    color: #991b1b;
-}
-
-.clear-failed-btn { font-size: 0.75rem; }
-
-/* Outbox queue card */
-#outbox-queue-card {
-    margin-top: 1rem;
-    background: #fff;
-    border: 1px solid #e2e8f0;
-    border-radius: 0.5rem;
-}
-#outbox-queue-card .card-header {
-    background: #f8fafc;
-    border-bottom: 1px solid #e2e8f0;
-}
-#outbox-queue-table {
-    font-size: 0.85rem;
-}
-#outbox-queue-table th {
-    font-weight: 600;
-    color: #475569;
-    text-transform: uppercase;
-    font-size: 0.7rem;
-    letter-spacing: 0.04em;
-}
-#outbox-queue-table td.error-cell {
-    max-width: 24em;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-family: ui-monospace, SFMono-Regular, monospace;
-    font-size: 0.75rem;
-    color: #991b1b;
-}
-.outbox-status-pill {
-    display: inline-block;
-    font-size: 0.7rem;
-    padding: 0.15rem 0.5rem;
-    border-radius: 999px;
-    font-weight: 600;
-    text-transform: uppercase;
-}
-.outbox-status-pill.pending   { background: #fef3c7; color: #92400e; }
-.outbox-status-pill.in_flight { background: #dbeafe; color: #1e40af; }
-.outbox-status-pill.done      { background: #dcfce7; color: #166534; }
-.outbox-status-pill.failed    { background: #fee2e2; color: #991b1b; }
-</style>
+<link rel="stylesheet" href="/assets/css/notifications.css?v=<?= time() ?>">
 
 <div class="dashboard-banner d-flex justify-content-between align-items-center flex-wrap gap-2">
     <div>
@@ -371,6 +155,74 @@ body:has(#notifications-channels-container) > footer {
         </dl>
       </div>
       <div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button></div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="outbox-inspector-modal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">
+          Outbox row <span id="inspector-row-id" class="text-muted"></span>
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="inspector-loading" class="text-center text-muted py-4">
+          <div class="spinner-border spinner-border-sm"></div> Loading&hellip;
+        </div>
+        <div id="inspector-content" hidden>
+          <dl class="row small inspector-summary mb-3">
+            <dt class="col-4">Status</dt>      <dd class="col-8" id="inspector-status"></dd>
+            <dt class="col-4">Channel</dt>     <dd class="col-8" id="inspector-channel"></dd>
+            <dt class="col-4">Call</dt>        <dd class="col-8" id="inspector-call"></dd>
+            <dt class="col-4">Intent</dt>      <dd class="col-8" id="inspector-intent"></dd>
+            <dt class="col-4">Attempts</dt>    <dd class="col-8" id="inspector-attempts"></dd>
+            <dt class="col-4">Next attempt</dt><dd class="col-8" id="inspector-next-attempt"></dd>
+            <dt class="col-4">Created</dt>     <dd class="col-8" id="inspector-created"></dd>
+            <dt class="col-4">Updated</dt>     <dd class="col-8" id="inspector-updated"></dd>
+          </dl>
+
+          <div id="inspector-error-wrap" class="mb-3" hidden>
+            <h6 class="small text-uppercase text-muted mb-1">Last error</h6>
+            <div class="inspector-error" id="inspector-error"></div>
+          </div>
+
+          <div id="inspector-schedule-wrap" class="mb-3" hidden>
+            <h6 class="small text-uppercase text-muted mb-1">Reschedule retry</h6>
+            <div class="d-flex gap-2 align-items-center flex-wrap">
+              <input type="datetime-local" class="form-control form-control-sm" id="inspector-schedule-input" step="60">
+              <button type="button" class="btn btn-sm btn-primary" id="inspector-schedule-btn">
+                <i class="bi bi-clock"></i> Save
+              </button>
+            </div>
+            <div class="schedule-feedback text-muted mt-1" id="inspector-schedule-feedback"></div>
+          </div>
+
+          <h6 class="small text-uppercase text-muted mb-1">Send-attempt history</h6>
+          <div class="table-responsive">
+            <table class="table table-sm history-table mb-0">
+              <thead>
+                <tr>
+                  <th>When</th>
+                  <th>OK</th>
+                  <th>HTTP</th>
+                  <th>Topic</th>
+                  <th>Duration</th>
+                  <th>Error</th>
+                </tr>
+              </thead>
+              <tbody id="inspector-history-tbody">
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div id="inspector-load-error" class="alert alert-danger small" hidden></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
     </div>
   </div>
 </div>
@@ -866,6 +718,12 @@ body:has(#notifications-channels-container) > footer {
         document.getElementById('outbox-refresh-btn').addEventListener('click', refresh);
         document.getElementById('outbox-clear-btn').addEventListener('click', clearAll);
 
+        // Inspector save button — bound once; reads currentInspectId at click time.
+        const scheduleBtn = document.getElementById('inspector-schedule-btn');
+        if (scheduleBtn) {
+            scheduleBtn.addEventListener('click', () => saveSchedule(currentInspectId));
+        }
+
         refresh();
     }
 
@@ -951,6 +809,17 @@ body:has(#notifications-channels-container) > footer {
         const td = document.createElement('td');
         td.className = 'text-end';
 
+        const inspectBtn = document.createElement('button');
+        inspectBtn.type = 'button';
+        inspectBtn.className = 'btn btn-sm btn-outline-secondary me-1';
+        inspectBtn.innerHTML = '<i class="bi bi-eye"></i>';
+        inspectBtn.title = 'Inspect this row';
+        inspectBtn.addEventListener('click', (ev) => {
+            ev.stopPropagation();
+            openInspector(row.id);
+        });
+        td.appendChild(inspectBtn);
+
         if (row.status === 'failed') {
             const retryBtn = document.createElement('button');
             retryBtn.type = 'button';
@@ -1015,6 +884,191 @@ body:has(#notifications-channels-container) > footer {
         } catch (err) {
             alert('Clear failed: ' + (err?.message ?? 'unknown'));
         }
+    }
+
+    /* ---------------- Inspector modal ---------------- */
+
+    let currentInspectId = null;
+
+    async function openInspector(id) {
+        currentInspectId = Number(id);
+        const modalEl = document.getElementById('outbox-inspector-modal');
+
+        document.getElementById('inspector-row-id').textContent = '#' + id;
+        document.getElementById('inspector-loading').hidden = false;
+        document.getElementById('inspector-content').hidden = true;
+        document.getElementById('inspector-load-error').hidden = true;
+
+        bootstrap.Modal.getOrCreateInstance(modalEl).show();
+
+        try {
+            const data = await Dashboard.apiRequest(`/notifications/outbox/${id}`);
+            renderInspector(data?.row ?? null, data?.history ?? []);
+        } catch (err) {
+            document.getElementById('inspector-loading').hidden = true;
+            const errEl = document.getElementById('inspector-load-error');
+            errEl.hidden = false;
+            errEl.textContent = err?.message ?? 'Failed to load row';
+        }
+    }
+
+    function renderInspector(row, history) {
+        document.getElementById('inspector-loading').hidden = true;
+        if (!row) {
+            const errEl = document.getElementById('inspector-load-error');
+            errEl.hidden = false;
+            errEl.textContent = 'Row not found.';
+            return;
+        }
+        document.getElementById('inspector-content').hidden = false;
+
+        const statusEl = document.getElementById('inspector-status');
+        statusEl.textContent = '';
+        const pill = document.createElement('span');
+        pill.className = `outbox-status-pill ${row.status}`;
+        pill.textContent = row.status;
+        statusEl.appendChild(pill);
+
+        document.getElementById('inspector-channel').textContent =
+            (row.channel_name ?? `#${row.channel_id}`) + (row.channel_type ? ` (${row.channel_type})` : '');
+        document.getElementById('inspector-call').textContent =
+            row.call_number ?? `#${row.db_call_id}`;
+        document.getElementById('inspector-intent').textContent = row.intent ?? '—';
+        document.getElementById('inspector-attempts').textContent = String(row.attempts ?? 0);
+        document.getElementById('inspector-next-attempt').textContent =
+            row.next_attempt_at ? Dashboard.formatTime(row.next_attempt_at) : '—';
+        document.getElementById('inspector-created').textContent =
+            row.created_at ? Dashboard.formatTime(row.created_at) : '—';
+        document.getElementById('inspector-updated').textContent =
+            row.updated_at ? Dashboard.formatTime(row.updated_at) : '—';
+
+        const errWrap = document.getElementById('inspector-error-wrap');
+        const errEl = document.getElementById('inspector-error');
+        if (row.last_error) {
+            errWrap.hidden = false;
+            errEl.textContent = row.last_error;
+        } else {
+            errWrap.hidden = true;
+            errEl.textContent = '';
+        }
+
+        // Reschedule control: only pending or failed rows can be rescheduled.
+        const scheduleWrap = document.getElementById('inspector-schedule-wrap');
+        const scheduleInput = document.getElementById('inspector-schedule-input');
+        const scheduleFb = document.getElementById('inspector-schedule-feedback');
+        scheduleFb.textContent = '';
+        scheduleFb.classList.remove('text-success', 'text-danger');
+        if (row.status === 'pending' || row.status === 'failed') {
+            scheduleWrap.hidden = false;
+            scheduleInput.value = toLocalDatetimeInputValue(row.next_attempt_at);
+        } else {
+            scheduleWrap.hidden = true;
+        }
+
+        renderHistory(history);
+    }
+
+    function renderHistory(history) {
+        const tbody = document.getElementById('inspector-history-tbody');
+        tbody.replaceChildren();
+        if (!history || history.length === 0) {
+            const tr = document.createElement('tr');
+            const td = document.createElement('td');
+            td.colSpan = 6;
+            td.className = 'text-center text-muted py-2 small';
+            td.textContent = 'No send attempts recorded.';
+            tr.appendChild(td);
+            tbody.appendChild(tr);
+            return;
+        }
+        history.forEach((h) => {
+            const tr = document.createElement('tr');
+            appendHistoryCell(tr, Dashboard.formatTime(h.created_at));
+            const okTd = document.createElement('td');
+            const okSpan = document.createElement('span');
+            const isOk = !!Number(h.ok);
+            okSpan.className = 'http-pill ' + (isOk ? 'ok' : 'fail');
+            okSpan.textContent = isOk ? '✓' : '✗';
+            okTd.appendChild(okSpan);
+            tr.appendChild(okTd);
+            appendHistoryCell(tr, h.http_status != null ? String(h.http_status) : '—');
+            appendHistoryCell(tr, h.topic ?? '—');
+            appendHistoryCell(tr, `${h.duration_ms ?? 0} ms`);
+            const errTd = document.createElement('td');
+            errTd.className = 'history-error';
+            if (h.error) {
+                errTd.title = h.error;
+                errTd.textContent = h.error;
+            } else {
+                errTd.textContent = '—';
+            }
+            tr.appendChild(errTd);
+            tbody.appendChild(tr);
+        });
+    }
+
+    function appendHistoryCell(tr, text) {
+        const td = document.createElement('td');
+        td.textContent = text;
+        tr.appendChild(td);
+    }
+
+    async function saveSchedule(id) {
+        if (id == null) return;
+        const input = document.getElementById('inspector-schedule-input');
+        const fb = document.getElementById('inspector-schedule-feedback');
+        fb.classList.remove('text-success', 'text-danger');
+
+        const raw = (input.value ?? '').trim();
+        if (!raw) {
+            fb.classList.add('text-danger');
+            fb.textContent = 'Pick a date and time.';
+            return;
+        }
+        const when = fromLocalDatetimeInputValue(raw);
+        const btn = document.getElementById('inspector-schedule-btn');
+        btn.disabled = true;
+        try {
+            // Dashboard.apiRequest JSON.stringifies options.body itself — pass the object.
+            await Dashboard.apiRequest(`/notifications/outbox/${id}/schedule`, {
+                method: 'POST',
+                body: { next_attempt_at: when },
+            });
+            fb.classList.add('text-success');
+            fb.textContent = `Rescheduled to ${Dashboard.formatTime(when)}.`;
+            refresh();
+        } catch (err) {
+            fb.classList.add('text-danger');
+            fb.textContent = err?.message ?? 'Failed to reschedule.';
+        } finally {
+            btn.disabled = false;
+        }
+    }
+
+    /**
+     * Format a server-supplied datetime (UTC 'Y-m-d H:i:s' or null) as the local
+     * 'YYYY-MM-DDTHH:MM' string expected by <input type="datetime-local">.
+     * Empty input → default to "now + 1 minute" so the picker isn't blank.
+     */
+    function toLocalDatetimeInputValue(serverDt) {
+        let d;
+        if (serverDt) {
+            d = new Date(String(serverDt).replace(' ', 'T') + 'Z');
+            if (isNaN(d)) d = new Date(Date.now() + 60_000);
+        } else {
+            d = new Date(Date.now() + 60_000);
+        }
+        const pad = (n) => String(n).padStart(2, '0');
+        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    }
+
+    /**
+     * Convert a 'YYYY-MM-DDTHH:MM' (local) value back to ISO 8601 with the
+     * client's offset, which DateTimeImmutable on the server parses correctly.
+     */
+    function fromLocalDatetimeInputValue(local) {
+        const d = new Date(local);
+        return isNaN(d) ? local : d.toISOString();
     }
 
     if (document.readyState === 'loading') {

--- a/src/Dashboard/Views/partials/analytics-modal.php
+++ b/src/Dashboard/Views/partials/analytics-modal.php
@@ -85,7 +85,7 @@
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
                                         <h6 class="text-muted mb-1">Top Call Type</h6>
-                                        <h2 class="mb-0" id="analytics-stat-toptype" style="font-size: 0.9rem;">
+                                        <h2 class="mb-0 stat-title-compact-sm" id="analytics-stat-toptype">
                                             <span class="spinner-border spinner-border-sm"></span>
                                         </h2>
                                         <span class="summary-chips mt-1" id="analytics-stat-toptype-pill"></span>

--- a/src/Dashboard/Views/partials/map-and-stats.php
+++ b/src/Dashboard/Views/partials/map-and-stats.php
@@ -190,7 +190,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                <button type="button" class="btn btn-primary" onclick="viewCallDetails(window.currentModalCallId)">
+                <button type="button" id="map-modal-view-details-btn" class="btn btn-primary" data-popup-action="view-call">
                     <i class="bi bi-eye"></i> View Full Details
                 </button>
             </div>

--- a/src/Dashboard/Views/partials/map-and-stats.php
+++ b/src/Dashboard/Views/partials/map-and-stats.php
@@ -1,7 +1,7 @@
 <!-- Statistics Cards Row - 4 across at the top -->
 <div class="row mb-0" id="stats-cards">
     <div class="col-lg-3 col-md-6 col-sm-6 mb-2">
-        <div class="card stat-card-v2 is-total clickable-stat" data-bs-toggle="modal" data-bs-target="#filters-modal" style="cursor: pointer;">
+        <div class="card stat-card-v2 is-total clickable-stat" data-bs-toggle="modal" data-bs-target="#filters-modal">
             <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
@@ -20,7 +20,7 @@
     </div>
 
     <div class="col-lg-3 col-md-6 col-sm-6 mb-2">
-        <div class="card stat-card-v2 is-active clickable-stat" onclick="filterDashboard('active')" style="cursor: pointer;">
+        <div class="card stat-card-v2 is-active clickable-stat" onclick="filterDashboard('active')">
             <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
@@ -39,7 +39,7 @@
     </div>
 
     <div class="col-lg-3 col-md-6 col-sm-6 mb-2">
-        <div class="card stat-card-v2 is-closed clickable-stat" onclick="filterDashboard('closed')" style="cursor: pointer;">
+        <div class="card stat-card-v2 is-closed clickable-stat" onclick="filterDashboard('closed')">
             <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
@@ -58,12 +58,12 @@
     </div>
 
     <div class="col-lg-3 col-md-6 col-sm-6 mb-2">
-        <div class="card stat-card-v2 is-analytics clickable-stat" data-bs-toggle="modal" data-bs-target="#analytics-modal" style="cursor: pointer;">
+        <div class="card stat-card-v2 is-analytics clickable-stat" data-bs-toggle="modal" data-bs-target="#analytics-modal">
             <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
                         <h6 class="text-muted mb-1">Analytics</h6>
-                        <h2 class="mb-0" style="font-size: 1.2rem;">
+                        <h2 class="mb-0 stat-title-compact">
                             <i class="bi bi-graph-up"></i> View Charts
                         </h2>
                         <span class="summary-chips mt-1" id="stat-analytics-pill"></span>
@@ -108,14 +108,14 @@
                     <table class="table table-hover mb-0">
                         <thead class="table-light sticky-top">
                             <tr>
-                                <th style="width: 9%;">Call ID</th>
-                                <th style="width: 13%;">Received</th>
-                                <th style="width: 20%;">Call Type</th>
-                                <th style="width: 19%;">Location</th>
-                                <th style="width: 10%;">Priority</th>
-                                <th style="width: 10%;">Status</th>
-                                <th style="width: 9%;">Units</th>
-                                <th style="width: 10%;">Map</th>
+                                <th class="col-w-9">Call ID</th>
+                                <th class="col-w-13">Received</th>
+                                <th class="col-w-20">Call Type</th>
+                                <th class="col-w-19">Location</th>
+                                <th class="col-w-10">Priority</th>
+                                <th class="col-w-10">Status</th>
+                                <th class="col-w-9">Units</th>
+                                <th class="col-w-10">Map</th>
                             </tr>
                         </thead>
                         <tbody id="recent-calls-body">
@@ -131,7 +131,7 @@
                     </table>
                 </div>
                 <!-- Pagination Controls -->
-                <div class="d-flex justify-content-between align-items-center p-3 border-top" id="calls-pagination-container" style="display: none !important;">
+                <div class="d-flex justify-content-between align-items-center p-3 border-top d-none" id="calls-pagination-container">
                     <div>
                         <small class="text-muted">
                             Showing <span id="calls-showing-start">0</span>-<span id="calls-showing-end">0</span> 
@@ -167,10 +167,10 @@
             </div>
             <div class="modal-body p-0">
                 <!-- Map Container -->
-                <div id="modal-map" style="height: 600px; width: 100%;"></div>
-                
+                <div id="modal-map"></div>
+
                 <!-- Call Info Card (Overlay) -->
-                <div class="card position-absolute" style="bottom: 20px; left: 20px; max-width: 350px; z-index: 1000; box-shadow: 0 4px 12px rgba(0,0,0,0.3);">
+                <div class="card position-absolute map-info-overlay">
                     <div class="card-body p-3">
                         <h6 class="card-title mb-2" id="map-modal-call-type">Loading...</h6>
                         <p class="card-text small mb-1">

--- a/src/Notifications/Outbox/OutboxRepository.php
+++ b/src/Notifications/Outbox/OutboxRepository.php
@@ -216,6 +216,69 @@ final class OutboxRepository implements OutboxRepositoryInterface
         });
     }
 
+    public function findById(int $rowId): ?array
+    {
+        return $this->exec(function (PDO $db) use ($rowId): ?array {
+            $stmt = $db->prepare(
+                "SELECT o.id, o.db_call_id, o.channel_id, o.intent, o.resend_all,
+                        o.added_topics_json, o.create_datetime,
+                        o.status, o.attempts, o.next_attempt_at, o.claimed_at,
+                        o.claimed_by, o.last_error, o.created_at, o.updated_at,
+                        nc.name AS channel_name, nc.type AS channel_type,
+                        c.call_number
+                 FROM notification_outbox o
+                 LEFT JOIN notification_channels nc ON nc.id = o.channel_id
+                 LEFT JOIN calls c ON c.id = o.db_call_id
+                 WHERE o.id = ?
+                 LIMIT 1"
+            );
+            $stmt->execute([$rowId]);
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+            return $row === false ? null : $row;
+        });
+    }
+
+    public function listSendHistory(int $channelId, int $callId, string $intent, int $limit): array
+    {
+        return $this->exec(function (PDO $db) use ($channelId, $callId, $intent, $limit): array {
+            $stmt = $db->prepare(
+                "SELECT id, channel_id, call_id, intent, topic, ok, http_status,
+                        duration_ms, error, actor, created_at
+                 FROM notification_send_log
+                 WHERE channel_id = ? AND call_id = ? AND intent = ?
+                 ORDER BY id DESC
+                 LIMIT ?"
+            );
+            $stmt->bindValue(1, $channelId, PDO::PARAM_INT);
+            $stmt->bindValue(2, $callId, PDO::PARAM_INT);
+            $stmt->bindValue(3, $intent);
+            $stmt->bindValue(4, $limit, PDO::PARAM_INT);
+            $stmt->execute();
+            return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+        });
+    }
+
+    public function reschedule(int $rowId, DateTimeImmutable $nextAttemptAt): bool
+    {
+        return $this->exec(function (PDO $db) use ($rowId, $nextAttemptAt): bool {
+            $stmt = $db->prepare(
+                "UPDATE notification_outbox
+                 SET status = 'pending',
+                     next_attempt_at = ?,
+                     claimed_at = NULL,
+                     claimed_by = NULL,
+                     updated_at = CURRENT_TIMESTAMP
+                 WHERE id = ?
+                   AND status IN ('pending', 'failed')"
+            );
+            $stmt->execute([
+                $nextAttemptAt->format('Y-m-d H:i:s'),
+                $rowId,
+            ]);
+            return $stmt->rowCount() > 0;
+        });
+    }
+
     public function retry(int $rowId): bool
     {
         return $this->exec(function (PDO $db) use ($rowId): bool {

--- a/src/Notifications/Outbox/OutboxRepositoryInterface.php
+++ b/src/Notifications/Outbox/OutboxRepositoryInterface.php
@@ -55,6 +55,30 @@ interface OutboxRepositoryInterface
     public function listByStatus(string $status, int $limit): array;
 
     /**
+     * Fetch a single row joined with channel name/type and call_number for the
+     * per-row inspector. Returns null if not found.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function findById(int $rowId): ?array;
+
+    /**
+     * Recent send_log entries matching the outbox row's (channel, call, intent)
+     * tuple, newest first. Used by the inspector to show send-attempt history.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function listSendHistory(int $channelId, int $callId, string $intent, int $limit): array;
+
+    /**
+     * Reschedule a row: set next_attempt_at to the supplied time and put it
+     * back in 'pending' so the worker re-picks it at that time. Keeps attempts
+     * and last_error intact (the reschedule is purely a deferral). Only
+     * pending and failed rows can be rescheduled. Returns true if updated.
+     */
+    public function reschedule(int $rowId, DateTimeImmutable $nextAttemptAt): bool;
+
+    /**
      * Operator-initiated retry: reset a failed (or any) row to pending with
      * cleared backoff state. Returns true if a row was updated.
      */

--- a/src/Security/SecurityHeaders.php
+++ b/src/Security/SecurityHeaders.php
@@ -62,11 +62,13 @@ class SecurityHeaders
     /**
      * Set Content-Security-Policy header
      *
-     * The default policy uses a per-request nonce for inline scripts (no
-     * 'unsafe-inline' in script-src). 'unsafe-eval' remains for compatibility
-     * with libraries like Chart.js and Leaflet.js that compile expressions at
-     * runtime. Style attribute hardening (style-src nonces or hashes) is a
-     * separate follow-up.
+     * Both script-src and style-src use the same per-request nonce — no
+     * 'unsafe-inline' in either directive. 'unsafe-eval' remains for
+     * compatibility with libraries like Chart.js and Leaflet.js that compile
+     * expressions at runtime. JS-driven CSSOM property writes
+     * (e.g. element.style.display = 'none') are not gated by style-src per
+     * CSP3, so those continue to work; only literal <style> blocks and
+     * style="" attributes in served HTML are blocked.
      *
      * @param string|null $policy Custom CSP policy (default: nonce-based for dashboard compatibility)
      * @return void
@@ -78,7 +80,7 @@ class SecurityHeaders
             $policy = implode('; ', [
                 "default-src 'self'",
                 "script-src 'self' 'nonce-{$nonce}' 'unsafe-eval' https://cdn.jsdelivr.net https://unpkg.com https://*.cloudflare.com",
-                "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://fonts.googleapis.com",
+                "style-src 'self' 'nonce-{$nonce}' https://cdn.jsdelivr.net https://unpkg.com https://fonts.googleapis.com",
                 "img-src 'self' data: https://cdn.jsdelivr.net https://*.tile.openstreetmap.org",
                 "font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com",
                 "connect-src 'self'",

--- a/tests/Integration/Notifications/OutboxRepositoryTest.php
+++ b/tests/Integration/Notifications/OutboxRepositoryTest.php
@@ -311,6 +311,100 @@ final class OutboxRepositoryTest extends TestCase
         $this->assertSame(1, $remaining);
     }
 
+    public function testFindByIdReturnsJoinedRow(): void
+    {
+        $id = $this->insertPending();
+
+        $row = $this->repo->findById($id);
+        $this->assertIsArray($row);
+        $this->assertSame($id, (int) $row['id']);
+        $this->assertSame('ntfy_primary', $row['channel_name']);
+        $this->assertSame('ntfy', $row['channel_type']);
+        $this->assertSame('C-1', $row['call_number']);
+    }
+
+    public function testFindByIdReturnsNullForMissingRow(): void
+    {
+        $this->assertNull($this->repo->findById(99999));
+    }
+
+    public function testListSendHistoryFiltersByChannelCallAndIntent(): void
+    {
+        // Two matching entries plus one mismatching channel.
+        self::$db->exec("INSERT INTO notification_send_log (channel_id, call_id, intent, topic, ok, http_status, duration_ms, error) VALUES ({$this->channelId}, {$this->callId}, 'Created', 't1', 1, 200, 42, NULL)");
+        self::$db->exec("INSERT INTO notification_send_log (channel_id, call_id, intent, topic, ok, http_status, duration_ms, error) VALUES ({$this->channelId}, {$this->callId}, 'Created', 't1', 0, 503, 91, 'HTTP 503')");
+        self::$db->exec("INSERT INTO notification_send_log (channel_id, call_id, intent, topic, ok, http_status, duration_ms, error) VALUES ({$this->channelId}, {$this->callId}, 'Updated', 't1', 1, 200, 50, NULL)");
+
+        // Different channel.
+        self::$db->exec("INSERT INTO notification_channels (name, type, enabled, base_url, config_json) VALUES ('other', 'pushover', 1, 'https://x', '{}')");
+        $otherChannelId = (int) self::$db->lastInsertId();
+        self::$db->exec("INSERT INTO notification_send_log (channel_id, call_id, intent, topic, ok, http_status, duration_ms, error) VALUES ({$otherChannelId}, {$this->callId}, 'Created', 't1', 1, 200, 30, NULL)");
+
+        $history = $this->repo->listSendHistory($this->channelId, $this->callId, 'Created', 50);
+        $this->assertCount(2, $history);
+        // Newest first.
+        $this->assertSame(0, (int) $history[0]['ok']);
+        $this->assertSame('HTTP 503', $history[0]['error']);
+    }
+
+    public function testListSendHistoryHonorsLimit(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            self::$db->exec("INSERT INTO notification_send_log (channel_id, call_id, intent, topic, ok, http_status, duration_ms, error) VALUES ({$this->channelId}, {$this->callId}, 'Created', 't1', 1, 200, 10, NULL)");
+        }
+        $history = $this->repo->listSendHistory($this->channelId, $this->callId, 'Created', 3);
+        $this->assertCount(3, $history);
+    }
+
+    public function testRescheduleSetsNextAttemptAndKeepsAttemptsAndError(): void
+    {
+        $id = $this->insertPending();
+        $this->repo->markFailed($id, 5, 'retries exhausted');
+
+        $ok = $this->repo->reschedule($id, new DateTimeImmutable('2026-05-08 09:00:00'));
+        $this->assertTrue($ok);
+
+        $row = self::$db->query("SELECT status, attempts, next_attempt_at, last_error FROM notification_outbox WHERE id={$id}")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('pending', $row['status']);
+        $this->assertSame(5, (int) $row['attempts']);
+        $this->assertSame('2026-05-08 09:00:00', $row['next_attempt_at']);
+        $this->assertSame('retries exhausted', $row['last_error']);
+    }
+
+    public function testRescheduleAllowedForPendingRow(): void
+    {
+        $id = $this->insertPending();
+        $ok = $this->repo->reschedule($id, new DateTimeImmutable('2026-05-08 09:00:00'));
+        $this->assertTrue($ok);
+        $row = self::$db->query("SELECT next_attempt_at FROM notification_outbox WHERE id={$id}")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('2026-05-08 09:00:00', $row['next_attempt_at']);
+    }
+
+    public function testRescheduleRejectsInFlightRow(): void
+    {
+        $id = $this->insertPending();
+        self::$db->exec("UPDATE notification_outbox SET status='in_flight', claimed_by='w:1', claimed_at=NOW() WHERE id={$id}");
+
+        $ok = $this->repo->reschedule($id, new DateTimeImmutable('2026-05-08 09:00:00'));
+        $this->assertFalse($ok);
+        $row = self::$db->query("SELECT status FROM notification_outbox WHERE id={$id}")->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('in_flight', $row['status']);
+    }
+
+    public function testRescheduleRejectsDoneRow(): void
+    {
+        $id = $this->insertPending();
+        $this->repo->markDone($id);
+        $this->assertFalse($this->repo->reschedule($id, new DateTimeImmutable('2026-05-08 09:00:00')));
+    }
+
+    public function testRescheduleReturnsFalseForMissingRow(): void
+    {
+        $this->assertFalse($this->repo->reschedule(99999, new DateTimeImmutable('2026-05-08 09:00:00')));
+    }
+
     private function insertPending(): int
     {
         return $this->repo->insert(

--- a/tests/Integration/OutboxControllerTest.php
+++ b/tests/Integration/OutboxControllerTest.php
@@ -224,4 +224,112 @@ class OutboxControllerTest extends TestCase
         $this->assertFalse($payload['success']);
         $this->assertSame(400, http_response_code());
     }
+
+    public function testShowReturnsRowAndHistory(): void
+    {
+        $id = $this->insertPending();
+        self::$db->exec("INSERT INTO notification_send_log (channel_id, call_id, intent, topic, ok, http_status, duration_ms, error) VALUES ({$this->channelId}, {$this->callId}, 'Created', 't1', 0, 503, 99, 'HTTP 503')");
+
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->show((string) $id);
+        $payload = json_decode((string) ob_get_clean(), true);
+
+        $this->assertTrue($payload['success']);
+        $this->assertSame($id, (int) $payload['data']['row']['id']);
+        $this->assertSame('ntfy_primary', $payload['data']['row']['channel_name']);
+        $this->assertCount(1, $payload['data']['history']);
+        $this->assertSame('HTTP 503', $payload['data']['history'][0]['error']);
+    }
+
+    public function testShowReturns400ForNonNumericId(): void
+    {
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->show('abc');
+        $payload = json_decode((string) ob_get_clean(), true);
+        $this->assertFalse($payload['success']);
+        $this->assertSame(400, http_response_code());
+    }
+
+    public function testShowReturns404ForMissingId(): void
+    {
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->show('99999');
+        $payload = json_decode((string) ob_get_clean(), true);
+        $this->assertFalse($payload['success']);
+        $this->assertSame(404, http_response_code());
+    }
+
+    public function testScheduleUpdatesNextAttemptForFailedRow(): void
+    {
+        $id = $this->insertPending();
+        $this->repo->markFailed($id, 5, 'retries exhausted');
+
+        $_POST['next_attempt_at'] = '2026-05-08 09:00:00';
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->schedule((string) $id);
+        $payload = json_decode((string) ob_get_clean(), true);
+
+        $this->assertTrue($payload['success']);
+        $this->assertSame('2026-05-08 09:00:00', $payload['data']['next_attempt_at']);
+
+        $row = self::$db->query("SELECT status, next_attempt_at, attempts FROM notification_outbox WHERE id={$id}")
+            ->fetch(\PDO::FETCH_ASSOC);
+        $this->assertSame('pending', $row['status']);
+        $this->assertSame('2026-05-08 09:00:00', $row['next_attempt_at']);
+        $this->assertSame(5, (int) $row['attempts']);
+    }
+
+    public function testScheduleReturns400OnMissingBody(): void
+    {
+        $id = $this->insertPending();
+
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->schedule((string) $id);
+        $payload = json_decode((string) ob_get_clean(), true);
+        $this->assertFalse($payload['success']);
+        $this->assertSame(400, http_response_code());
+    }
+
+    public function testScheduleReturns400OnInvalidDateTime(): void
+    {
+        $id = $this->insertPending();
+        $_POST['next_attempt_at'] = 'not a date';
+
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->schedule((string) $id);
+        $payload = json_decode((string) ob_get_clean(), true);
+        $this->assertFalse($payload['success']);
+        $this->assertSame(400, http_response_code());
+    }
+
+    public function testScheduleReturns400OnNonNumericId(): void
+    {
+        $_POST['next_attempt_at'] = '2026-05-08 09:00:00';
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->schedule('abc');
+        $payload = json_decode((string) ob_get_clean(), true);
+        $this->assertFalse($payload['success']);
+        $this->assertSame(400, http_response_code());
+    }
+
+    public function testScheduleReturns404OnInFlightRow(): void
+    {
+        $id = $this->insertPending();
+        self::$db->exec("UPDATE notification_outbox SET status='in_flight', claimed_by='w:1', claimed_at=NOW() WHERE id={$id}");
+
+        $_POST['next_attempt_at'] = '2026-05-08 09:00:00';
+        $controller = new OutboxController($this->repo);
+        ob_start();
+        $controller->schedule((string) $id);
+        $payload = json_decode((string) ob_get_clean(), true);
+        $this->assertFalse($payload['success']);
+        $this->assertSame(404, http_response_code());
+    }
 }


### PR DESCRIPTION
## Summary
- **style-src CSP hardening** — drop `'unsafe-inline'` from `style-src` and add the per-request nonce (mirrors #33's `script-src` treatment). Required extracting `notifications.php`'s 200-line inline `<style>` block to `public/assets/css/notifications.css`, plus cleaning every remaining inline `style="..."` attribute across the dashboard/mobile views (utility classes added to `dashboard.css`, two JS spots switched from `.style.display` to `classList.toggle('d-none', ...)`).
- **Outbox per-row inspector + reschedule** — new modal on the notifications page with row summary, last_error, send-attempt history (joined from `notification_send_log` on `channel_id, call_id, intent`), and a native `<input type="datetime-local">` reschedule control. Backed by `GET /api/notifications/outbox/{id}` and `POST /api/notifications/outbox/{id}/schedule`. Reschedule is status-guarded — only `pending`/`failed` rows accept it; `in_flight` is owned by the worker, `done` shouldn't re-fire.
- **Map markers + popup actions under strict CSP** (`b319a1d`, follow-up) — the two CSP commits stripped every inline `style=""` and `onclick` at render time, leaving the map view with bare Bootstrap icons (no round colored badge) and dead popup CTAs. Marker styles move into `.marker-circle` + `.marker-circle--{color}` classes in `dashboard.css`; `maps.js` returns class names instead of hex codes. Popup CTAs and the map-zoom modal's "View Full Details" button use `data-popup-action` + `data-call-id` dispatched by a single document-level click delegator. The modal-open path writes `data-call-id` from JS, replacing the `window.currentModalCallId` global. Mobile map popup gets the same class-based + delegated treatment in `mobile.css` / `mobile.js` under a distinct `mobile-view-call` action. Deletes the dead unit-marker path from `maps.js` (`addUnitMarker` / `showUnits` / `createUnitPopup` had no callers; `viewUnitDetails` was never defined and no `unit-detail-modal` element exists).

## Test plan
- [x] `phpunit` — 507 tests pass (3 skipped, env-dependent); 11 new repo/controller cases cover happy paths, missing-row 404s, invalid-id/datetime 400s, in-flight/done rejection, and history filter/limit/order.
- [x] `curl -I /notifications` — `Content-Security-Policy: ... style-src 'self' 'nonce-...' ...` (no `'unsafe-inline'`).
- [x] `curl /notifications` + `grep style=` — zero inline style attributes in rendered HTML.
- [x] `curl` smoke-tests on `GET /api/notifications/outbox/{id}`, `POST .../schedule` — 200/400/404 paths return the expected JSON shapes.
- [ ] **Manual browser smoke** — load `/` and `/notifications` and confirm no CSP violations in the console (Bootstrap modals, Choices.js, Flatpickr, Leaflet — all confirmed via grep to use CSSOM or external CSS, but worth verifying live). Open the outbox inspector for a failed row and reschedule it.
- [ ] **Map smoke** (added with `b319a1d`) — verify call markers render as round colored badges; click a marker and confirm the popup "View Details" opens the call modal; open the map-zoom modal and confirm "View Full Details" opens the call modal; on the mobile dashboard, confirm the map popup "View Details" opens the mobile call detail view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)