### PR TITLE
fix(mobile): restore pins, click-to-open, defaults, and add pager

### DIFF
--- a/public/assets/css/mobile.css
+++ b/public/assets/css/mobile.css
@@ -352,6 +352,22 @@ body.mobile-view {
     border-radius: 12px;
 }
 
+/* Mobile Pager */
+.mobile-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin: 16px 0 24px;
+}
+
+.mobile-pagination-info {
+    font-size: 0.875rem;
+    color: #6c757d;
+    flex: 1;
+    text-align: center;
+}
+
 /* Mobile Empty State */
 .mobile-empty-state {
     text-align: center;

--- a/public/assets/js/mobile.js
+++ b/public/assets/js/mobile.js
@@ -39,15 +39,11 @@ const MobileDashboard = {
     async init() {
         console.log('[Mobile] Initializing mobile dashboard');
 
-        // Pre-populate URL with sensible defaults (today + open) on any fresh
-        // page load. Matches the desktop dispatcher's default view; FilterPanel's
-        // "Restore last filter?" banner still lets users recover a saved state.
-        if (!window.location.search) {
-            const url = new URL(window.location);
-            url.searchParams.set('preset', 'today');
-            url.searchParams.set('status', 'open');
-            window.history.replaceState({}, '', url);
-        }
+        // Whether this load arrived with a bare URL. Captured before mount so
+        // we can inject sensible defaults AFTER FilterPanel has had a chance
+        // to render its "Restore last filter?" banner, which exits early when
+        // window.location.search is non-empty.
+        const wasFreshLoad = !window.location.search;
 
         // Initialize FilterPanel (compact mode). The panel lives inside an
         // offcanvas drawer that's toggled by the filter stat-card; no explicit
@@ -65,6 +61,20 @@ const MobileDashboard = {
                 },
             });
             await this.panel.mount();
+
+            // Now that mount() has rendered any restore banner, inject the
+            // dispatcher's default view (today + open) and sync FilterPanel
+            // via a synthetic popstate — its popstate handler rebuilds state
+            // from the URL. Users still have ~6s to click "Restore" before
+            // the banner auto-dismisses.
+            if (wasFreshLoad) {
+                const url = new URL(window.location);
+                url.searchParams.set('preset', 'today');
+                url.searchParams.set('status', 'open');
+                window.history.replaceState({}, '', url);
+                window.dispatchEvent(new PopStateEvent('popstate'));
+            }
+
             this.currentQs = this.panel.getState().toQueryString();
         }
 
@@ -213,9 +223,24 @@ const MobileDashboard = {
 
             const data = await Dashboard.apiRequest(`/calls?${baseParams.toString()}`);
 
-            this.totalCalls = data.pagination?.total || 0;
-            this.totalPages = Math.max(1, data.pagination?.total_pages || 1);
-            // Server may clamp the page; reflect what was actually returned.
+            const total      = data.pagination?.total || 0;
+            const totalPages = Math.max(1, data.pagination?.total_pages || 1);
+
+            // CallsController returns the requested page verbatim — it does
+            // NOT clamp to total_pages. If live updates shrank the result set,
+            // we may be holding a now-invalid page index. Re-request the last
+            // real page once (guarded against loops).
+            if (total > 0 && this.currentPage > totalPages && !this._clampingPage) {
+                this._clampingPage = true;
+                this.currentPage = totalPages;
+                this.totalPages  = totalPages;
+                this.totalCalls  = total;
+                return this.loadCallsList();
+            }
+            this._clampingPage = false;
+
+            this.totalCalls = total;
+            this.totalPages = totalPages;
             this.currentPage = data.pagination?.current_page || this.currentPage;
             this.renderCallsList(data.items || []);
             this.updatePagination();
@@ -1446,16 +1471,17 @@ document.addEventListener('click', (event) => {
     }
 });
 
-// Keyboard accessibility for the role="button" call-list items.
+// Keyboard accessibility for every role="button" element that carries a
+// data-mobile-action (call rows, stat cards, etc.). Real <button> elements
+// like the pager controls already activate on Enter/Space natively, so we
+// scope this to role="button" to avoid double-firing. Dispatching a synthetic
+// click reuses the click delegator above — single source of truth.
 document.addEventListener('keydown', (event) => {
     if (event.key !== 'Enter' && event.key !== ' ') return;
-    const target = event.target.closest('[data-mobile-action="open-call"]');
+    const target = event.target.closest('[data-mobile-action][role="button"]');
     if (!target) return;
     event.preventDefault();
-    const id = parseInt(target.dataset.callId, 10);
-    if (Number.isFinite(id)) {
-        MobileDashboard.openCallDetails(id);
-    }
+    target.click();
 });
 
 // Initialize when DOM is ready

--- a/public/assets/js/mobile.js
+++ b/public/assets/js/mobile.js
@@ -38,11 +38,12 @@ const MobileDashboard = {
     async init() {
         console.log('[Mobile] Initializing mobile dashboard');
 
-        // Pre-populate URL with sensible defaults (last 7 days + open) when
-        // there's no existing URL state and no saved state.
-        if (!window.location.search && !localStorage.getItem('filter-panel:last-state')) {
+        // Pre-populate URL with sensible defaults (today + open) on any fresh
+        // page load. Matches the desktop dispatcher's default view; FilterPanel's
+        // "Restore last filter?" banner still lets users recover a saved state.
+        if (!window.location.search) {
             const url = new URL(window.location);
-            url.searchParams.set('preset', 'last_7_days');
+            url.searchParams.set('preset', 'today');
             url.searchParams.set('status', 'open');
             window.history.replaceState({}, '', url);
         }
@@ -221,7 +222,7 @@ const MobileDashboard = {
                     <i class="bi bi-exclamation-triangle"></i>
                     <h4>Error Loading Calls</h4>
                     <p>${this.escapeHtml(error.message)}</p>
-                    <button class="btn btn-primary mt-3" onclick="MobileDashboard.loadCallsList()">
+                    <button class="btn btn-primary mt-3" data-mobile-action="retry-calls-list">
                         Try Again
                     </button>
                 </div>
@@ -276,7 +277,7 @@ const MobileDashboard = {
         }
         
         return `
-            <div class="mobile-call-item" onclick="MobileDashboard.openCallDetails(${callId})">
+            <div class="mobile-call-item" data-mobile-action="open-call" data-call-id="${callId}" role="button" tabindex="0">
                 <div class="mobile-call-header">
                     <span class="mobile-call-id">#${this.escapeHtml(String(call.call_number || call.call_id))}</span>
                     <span class="mobile-call-time">${this.formatTime(call.create_datetime)}</span>
@@ -1241,7 +1242,22 @@ const MobileAnalytics = {
 const MobileMaps = {
     map: null,
     markers: [],
-    
+
+    /**
+     * Map numeric priority to the marker-circle color class defined in
+     * dashboard.css. Mirrors MapManager.getCallIconColorClass from maps.js
+     * (not loaded on mobile, so duplicated here).
+     */
+    getCallIconColorClass(priority) {
+        const classes = {
+            1: 'marker-circle--red',
+            2: 'marker-circle--yellow',
+            3: 'marker-circle--blue',
+            4: 'marker-circle--green'
+        };
+        return classes[priority] || 'marker-circle--gray';
+    },
+
     /**
      * Initialize map
      */
@@ -1299,9 +1315,10 @@ const MobileMaps = {
                 const locationText = call.location?.address || 'No location';
                 const callNumber = call.call_number || call.call_id;
                 const callId = parseInt(call.id, 10);
-                
+                const priority = Array.isArray(call.priorities) ? call.priorities[0] : call.priority;
+
                 if (isNaN(callId)) return;
-                
+
                 const popupContent = `
                     <div class="mobile-map-popup">
                         <strong class="popup-call-type">${MobileDashboard.escapeHtml(callType)}</strong><br>
@@ -1317,8 +1334,20 @@ const MobileMaps = {
                         </button>
                     </div>
                 `;
-                
-                const marker = L.marker([lat, lng])
+
+                // CSP img-src forbids unpkg.com, so default Leaflet PNG markers
+                // (https://unpkg.com/leaflet@.../images/marker-icon.png) are blocked.
+                // Use the same HTML-only divIcon scheme as the desktop MapManager;
+                // .custom-marker / .marker-circle classes live in dashboard.css.
+                const colorClass = MobileMaps.getCallIconColorClass(priority);
+                const icon = L.divIcon({
+                    className: 'custom-marker',
+                    html: `<div class="marker-circle ${colorClass}"><i class="bi bi-telephone-fill"></i></div>`,
+                    iconSize: [30, 30],
+                    iconAnchor: [15, 15]
+                });
+
+                const marker = L.marker([lat, lng], { icon })
                     .bindPopup(popupContent);
                 marker.addTo(this.map);
                 this.markers.push(marker);
@@ -1331,14 +1360,47 @@ const MobileMaps = {
     }
 };
 
-// Click delegation for mobile map popup buttons. CSP no longer permits inline
-// onclick handlers — see SecurityHeaders::setContentSecurityPolicy. Uses a
-// distinct action name from the desktop maps.js delegator so the two stay
-// independent on pages that load both bundles.
+// Click delegation. CSP no longer permits inline onclick handlers — see
+// SecurityHeaders::setContentSecurityPolicy. Single document-level listener
+// covers map popups, call-list rows, and stat-card filters. Uses distinct
+// action names from the desktop maps.js delegator so the two stay independent
+// on pages that load both bundles.
 document.addEventListener('click', (event) => {
-    const target = event.target.closest('[data-popup-action="mobile-view-call"]');
-    if (!target) return;
+    const popupBtn = event.target.closest('[data-popup-action="mobile-view-call"]');
+    if (popupBtn) {
+        const id = parseInt(popupBtn.dataset.callId, 10);
+        if (Number.isFinite(id)) {
+            MobileDashboard.openCallDetails(id);
+        }
+        return;
+    }
 
+    const actionEl = event.target.closest('[data-mobile-action]');
+    if (!actionEl) return;
+
+    switch (actionEl.dataset.mobileAction) {
+        case 'open-call': {
+            const id = parseInt(actionEl.dataset.callId, 10);
+            if (Number.isFinite(id)) {
+                MobileDashboard.openCallDetails(id);
+            }
+            break;
+        }
+        case 'filter-status':
+            MobileDashboard.filterByStatus(actionEl.dataset.status);
+            break;
+        case 'retry-calls-list':
+            MobileDashboard.loadCallsList();
+            break;
+    }
+});
+
+// Keyboard accessibility for the role="button" call-list items.
+document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const target = event.target.closest('[data-mobile-action="open-call"]');
+    if (!target) return;
+    event.preventDefault();
     const id = parseInt(target.dataset.callId, 10);
     if (Number.isFinite(id)) {
         MobileDashboard.openCallDetails(id);

--- a/public/assets/js/mobile.js
+++ b/public/assets/js/mobile.js
@@ -28,6 +28,7 @@ const MobileDashboard = {
     currentPage: 1,
     perPage: MOBILE_CONFIG.DEFAULT_PER_PAGE,
     totalCalls: 0,
+    totalPages: 1,
     refreshInterval: null,
     panel: null,
     currentQs: '',
@@ -211,9 +212,13 @@ const MobileDashboard = {
             }
 
             const data = await Dashboard.apiRequest(`/calls?${baseParams.toString()}`);
-            
+
             this.totalCalls = data.pagination?.total || 0;
+            this.totalPages = Math.max(1, data.pagination?.total_pages || 1);
+            // Server may clamp the page; reflect what was actually returned.
+            this.currentPage = data.pagination?.current_page || this.currentPage;
             this.renderCallsList(data.items || []);
+            this.updatePagination();
             
         } catch (error) {
             console.error('[Mobile] Error loading calls:', error);
@@ -246,6 +251,9 @@ const MobileDashboard = {
                     <p>Try adjusting your filters</p>
                 </div>
             `;
+            this.updateShowingText();
+            const pager = document.getElementById('mobile-calls-pagination');
+            if (pager) pager.classList.add('d-none');
             return;
         }
         
@@ -335,12 +343,47 @@ const MobileDashboard = {
      * Update showing text
      */
     updateShowingText() {
-        const start = (this.currentPage - 1) * this.perPage + 1;
+        const start = this.totalCalls === 0 ? 0 : (this.currentPage - 1) * this.perPage + 1;
         const end = Math.min(this.currentPage * this.perPage, this.totalCalls);
-        
+
         const showingEl = document.getElementById('mobile-showing-text');
         if (showingEl) {
             showingEl.textContent = `Showing ${start}-${end} of ${this.totalCalls}`;
+        }
+    },
+
+    /**
+     * Update the prev/next pager state.
+     */
+    updatePagination() {
+        const pager = document.getElementById('mobile-calls-pagination');
+        if (!pager) return;
+
+        const hasMultiplePages = this.totalPages > 1;
+        pager.classList.toggle('d-none', !hasMultiplePages);
+        if (!hasMultiplePages) return;
+
+        const prev = pager.querySelector('[data-mobile-action="prev-page"]');
+        const next = pager.querySelector('[data-mobile-action="next-page"]');
+        const info = document.getElementById('mobile-page-info');
+
+        if (prev) prev.disabled = this.currentPage <= 1;
+        if (next) next.disabled = this.currentPage >= this.totalPages;
+        if (info) info.textContent = `Page ${this.currentPage} of ${this.totalPages}`;
+    },
+
+    /**
+     * Move to a specific page and reload.
+     */
+    goToPage(page) {
+        const target = Math.max(1, Math.min(this.totalPages, parseInt(page, 10) || 1));
+        if (target === this.currentPage) return;
+        this.currentPage = target;
+        this.loadCallsList();
+        // Scroll the list into view so the next page starts at the top.
+        const callsView = document.getElementById('mobile-calls-view');
+        if (callsView && callsView.scrollIntoView) {
+            callsView.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
     },
     
@@ -993,7 +1036,9 @@ const MobileDashboard = {
             this.currentQs = qs;
         }
 
-        // Refresh data
+        // Changing the filter set should always restart at page 1; otherwise
+        // the previous page index leaks into the new result set.
+        this.currentPage = 1;
         this.refreshData();
     },
     
@@ -1391,6 +1436,12 @@ document.addEventListener('click', (event) => {
             break;
         case 'retry-calls-list':
             MobileDashboard.loadCallsList();
+            break;
+        case 'prev-page':
+            MobileDashboard.goToPage(MobileDashboard.currentPage - 1);
+            break;
+        case 'next-page':
+            MobileDashboard.goToPage(MobileDashboard.currentPage + 1);
             break;
     }
 });

--- a/src/Dashboard/Views/dashboard-mobile.php
+++ b/src/Dashboard/Views/dashboard-mobile.php
@@ -26,14 +26,14 @@
             </h2>
         </div>
         
-        <div class="mobile-stat-card border-danger" onclick="MobileDashboard.filterByStatus('active')">
+        <div class="mobile-stat-card border-danger" data-mobile-action="filter-status" data-status="active" role="button" tabindex="0">
             <h6>Active</h6>
             <h2 class="text-danger" id="stat-active">
                 <span class="spinner-border spinner-border-sm"></span>
             </h2>
         </div>
-        
-        <div class="mobile-stat-card border-success" onclick="MobileDashboard.filterByStatus('closed')">
+
+        <div class="mobile-stat-card border-success" data-mobile-action="filter-status" data-status="closed" role="button" tabindex="0">
             <h6>Closed</h6>
             <h2 class="text-success" id="stat-closed">
                 <span class="spinner-border spinner-border-sm"></span>

--- a/src/Dashboard/Views/dashboard-mobile.php
+++ b/src/Dashboard/Views/dashboard-mobile.php
@@ -60,6 +60,16 @@
         <div id="mobile-calls-list">
             <!-- Calls will be loaded here -->
         </div>
+
+        <nav id="mobile-calls-pagination" class="mobile-pagination d-none" aria-label="Calls pagination">
+            <button type="button" class="btn btn-outline-primary btn-sm" data-mobile-action="prev-page" disabled>
+                <i class="bi bi-chevron-left"></i> Prev
+            </button>
+            <span class="mobile-pagination-info" id="mobile-page-info">Page 1</span>
+            <button type="button" class="btn btn-outline-primary btn-sm" data-mobile-action="next-page" disabled>
+                Next <i class="bi bi-chevron-right"></i>
+            </button>
+        </nav>
     </div>
     
     <!-- Map View (Hidden by default) -->


### PR DESCRIPTION
## Summary

The mobile dashboard had three CSP-related regressions after #33 (dropped `script-src 'unsafe-inline'`) and #34, plus a long-standing gap in the calls list:

- **Map pins missing** — `mobile.js` used Leaflet's default `L.marker()` whose PNG icon is served from `unpkg.com`, which isn't in the CSP `img-src` whitelist. Switched to `L.divIcon` (HTML-only) reusing the existing `.custom-marker` / `.marker-circle--*` styles, matching the desktop `MapManager`.
- **Tapping an incident did nothing** — `mobile.js` and `dashboard-mobile.php` still had inline `onclick="..."` attributes (call rows, Active/Closed stat cards, the "Try Again" button). Inline event-handler attributes are blocked without `'unsafe-inline'`. Replaced them with `data-mobile-action` attributes wired through one document-level click delegator; rows now also have `role="button"` and a keyboard activation handler.
- **Default filter wasn't open + today** — `init()` set `preset=last_7_days` and gated the defaults on `!localStorage.getItem('filter-panel:last-state')`, so once any filter had ever been changed, defaults stopped applying. Now sets `preset=today` + `status=open` on any fresh URL, matching the desktop dispatcher view.
- **No pager on the calls list** — `MobileDashboard` already tracked `currentPage`/`perPage`/`totalCalls` but the view rendered no controls, leaving users stuck on page 1. Added a prev/next pager below `#mobile-calls-list`, hidden when `totalPages <= 1` or the result set is empty, and made the stat-card status filter reset `currentPage` so a deep page index doesn't leak into a new filter.

## Test plan

- [ ] Open the dashboard on a mobile UA; confirm URL becomes `?preset=today&status=open` on a fresh load.
- [ ] Tap a call row → detail modal opens (no console CSP error).
- [ ] Tap the Active and Closed stat cards → status filter updates, list reloads, no CSP error.
- [ ] Switch to the Map tab → pins appear; tap a pin → popup opens; tap "View Details" → modal opens.
- [ ] Load enough calls to span >1 page → pager appears, Prev/Next change page and update "Showing X-Y of N"; toggling Active/Closed resets to page 1.
- [ ] Trigger an error in the calls list → "Try Again" reloads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)