### PR TITLE
fix(mobile): header above map zoom + always-on live dot pulse

### DIFF
--- a/public/assets/css/mobile.css
+++ b/public/assets/css/mobile.css
@@ -30,7 +30,9 @@ body.mobile-view {
     height: var(--mobile-header-height);
     background: linear-gradient(135deg, #0d6efd 0%, #0a58ca 100%);
     color: white;
-    z-index: 1000;
+    /* Above Leaflet's .leaflet-top (z-index: 1000) so map zoom controls
+       can't scroll over the fixed header. */
+    z-index: 1030;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -206,7 +208,9 @@ body.mobile-view {
     display: flex;
     justify-content: space-around;
     align-items: center;
-    z-index: 1000;
+    /* Above Leaflet's .leaflet-bottom (z-index: 1000) so attribution and
+       bottom-positioned map controls can't scroll over the fixed nav. */
+    z-index: 1030;
     box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);
 }
 

--- a/public/assets/js/mobile.js
+++ b/public/assets/js/mobile.js
@@ -1149,9 +1149,6 @@ const MobileDashboard = {
         const indicator = document.querySelector('.mobile-live-indicator');
         if (indicator) {
             indicator.classList.add('pulse');
-            setTimeout(() => {
-                indicator.classList.remove('pulse');
-            }, 2000);
         }
     }
 };


### PR DESCRIPTION
## Summary
- Two small mobile UI fixes reported on real device use.
- Bumped `.mobile-header` and `.mobile-bottom-nav` from `z-index: 1000` to `1030` so Leaflet's zoom controls (`.leaflet-top` is `z-index: 1000`) can't scroll over the fixed header / nav.
- Dropped the 2s `setTimeout` in `MobileDashboard.updateLiveIndicator()`. The green dot now pulses continuously while live instead of going dark for 28 of every 30 seconds.

## Test plan
- [ ] On mobile, open the Map tab and scroll up — zoom buttons slide under the blue header, not over it.
- [ ] Watch the green "Live" dot in the header for 30+ seconds — it pulses continuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)