### PR TITLE
fix(mobile): scope live-dot pulse to the icon, not the container

### DIFF
--- a/public/assets/css/mobile.css
+++ b/public/assets/css/mobile.css
@@ -514,8 +514,10 @@ body.mobile-view {
     font-size: 0.6rem;
 }
 
-.mobile-live-indicator.pulse i {
-    animation: pulse 2s infinite;
+/* Animation comes from the global .pulse rule in dashboard.css; this rule
+   only paints the dot green while pulsing. The .pulse class lives on the
+   <i> (not the container) so the "Live" text stays opaque. */
+.mobile-live-indicator i.pulse {
     color: #198754 !important;
 }
 

--- a/public/assets/js/mobile.js
+++ b/public/assets/js/mobile.js
@@ -1143,12 +1143,17 @@ const MobileDashboard = {
     },
     
     /**
-     * Update live indicator with pulse animation
+     * Update live indicator with pulse animation.
+     *
+     * The .pulse class is applied to the inner <i> (the dot), not the
+     * container, so it doesn't pick up dashboard.css's global
+     * `.pulse { animation: pulse 2s infinite; }` rule on the whole indicator
+     * and fade the "Live" text along with the dot.
      */
     updateLiveIndicator() {
-        const indicator = document.querySelector('.mobile-live-indicator');
-        if (indicator) {
-            indicator.classList.add('pulse');
+        const dot = document.querySelector('.mobile-live-indicator i');
+        if (dot) {
+            dot.classList.add('pulse');
         }
     }
 };


### PR DESCRIPTION
## Summary
Follow-up to #40 addressing review feedback from qodo and Copilot.

`dashboard.css` defines a global `.pulse { animation: pulse 2s infinite; }`. v1.1.16 added the class to the `.mobile-live-indicator` container itself, which made the whole header pill (green dot **and** "Live" text) fade continuously instead of just the dot.

- JS now adds the `pulse` class to the inner `<i>` element.
- `mobile.css`'s `.mobile-live-indicator i.pulse` rule keeps the green color; the animation comes from the global `.pulse` rule.

## Test plan
- [ ] On mobile, watch the header for 10+ seconds — only the green dot fades in/out; the "Live" text stays opaque.
- [ ] Confirm the dot still pulses continuously while live (regression check from #40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)