### PR TITLE
test(import): test infra — importer characterization, FileWatcher coverage, Postgres CI, phpstan

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -213,3 +213,108 @@ jobs:
           if [ "$COVERAGE_BELOW_THRESHOLD" = "true" ]; then
             echo "⚠️  **Warning:** Code coverage is below 80% threshold" >> $GITHUB_STEP_SUMMARY
           fi
+
+  # PostgreSQL job: exercises the pgsql driver paths (parser UPSERT branches,
+  # DbHelper dialect switches) that the MySQL job never runs. Non-blocking
+  # (continue-on-error) until the pgsql suite is fully green — see #48. The
+  # importer characterization suite already passes on both drivers; the rest
+  # is being brought up incrementally.
+  test-postgres:
+    name: PostgreSQL ${{ matrix.php-version }} Tests
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.3']
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: nws_cad_test
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_pass
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U test_user"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: pdo, pdo_pgsql, xml, simplexml
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Wait for PostgreSQL
+        run: |
+          echo "Waiting for PostgreSQL to be ready..."
+          max_attempts=30
+          attempt=0
+          until pg_isready -h 127.0.0.1 -U test_user; do
+            attempt=$((attempt + 1))
+            if [ $attempt -ge $max_attempts ]; then
+              echo "::error::PostgreSQL failed to become ready after $max_attempts attempts"
+              exit 1
+            fi
+            echo "Attempt $attempt/$max_attempts: Waiting for PostgreSQL..."
+            sleep 2
+          done
+          echo "::notice::PostgreSQL is ready and accepting connections"
+
+      - name: Create database schema
+        env:
+          PGPASSWORD: test_pass
+        run: |
+          echo "Loading PostgreSQL schema into nws_cad_test..."
+          psql -h 127.0.0.1 -U test_user -d nws_cad_test -v ON_ERROR_STOP=1 -f database/postgres/init.sql
+          echo "::notice::PostgreSQL schema created successfully"
+
+      - name: Run Unit Tests
+        run: composer run-script test:unit
+        env:
+          DB_TYPE: pgsql
+          POSTGRES_HOST: 127.0.0.1
+          POSTGRES_PORT: 5432
+          # bootstrap.php treats POSTGRES_DB as the production name and redirects
+          # to POSTGRES_TEST_DATABASE before any TRUNCATE runs. Distinct values
+          # satisfy the safety guard; only nws_cad_test actually exists.
+          POSTGRES_DB: nws_cad
+          POSTGRES_TEST_DATABASE: nws_cad_test
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_pass
+
+      - name: Run Integration Tests
+        run: composer run-script test:integration
+        env:
+          DB_TYPE: pgsql
+          POSTGRES_HOST: 127.0.0.1
+          POSTGRES_PORT: 5432
+          POSTGRES_DB: nws_cad
+          POSTGRES_TEST_DATABASE: nws_cad_test
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_pass
+
+      - name: Run Security Tests
+        run: composer run-script test:security
+        env:
+          DB_TYPE: pgsql
+          POSTGRES_HOST: 127.0.0.1
+          POSTGRES_PORT: 5432
+          POSTGRES_DB: nws_cad
+          POSTGRES_TEST_DATABASE: nws_cad_test
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_pass

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
 
+      - name: Static analysis (PHPStan)
+        run: composer phpstan
+
       - name: Wait for MySQL
         run: |
           echo "Waiting for MySQL to be ready..."

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,11 @@
         "monolog/monolog": "^3.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
-        "phpunit/php-code-coverage": "^10.1",
         "fakerphp/faker": "^1.23",
-        "mockery/mockery": "^1.6"
+        "mockery/mockery": "^1.6",
+        "phpstan/phpstan": "^1.11",
+        "phpunit/php-code-coverage": "^10.1",
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {
@@ -38,6 +39,7 @@
         "test:performance": "phpunit --testsuite Performance",
         "test:security": "phpunit --testsuite Security",
         "test:coverage": "phpunit --coverage-html coverage",
-        "watch": "php src/watcher.php"
+        "watch": "php src/watcher.php",
+        "phpstan": "phpstan analyse --memory-limit=1G"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62cce38813fbf560c7838141ba868f2a",
+    "content-hash": "434490857ace481600ad6433ed9b581e",
     "packages": [
         {
             "name": "jaybizzle/crawler-detect",
@@ -790,6 +790,59 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.33",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-28T20:30:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2357,5 +2410,5 @@
         "ext-xml": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,26 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Match expression does not handle remaining value\\: string$#"
+			count: 1
+			path: src/Api/Controllers/FilterOptionsController.php
+
+		-
+			message: "#^Match expression does not handle remaining value\\: string$#"
+			count: 1
+			path: src/Api/Filtering/FilterSqlBuilder.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between mixed and null will always evaluate to false\\.$#"
+			count: 2
+			path: src/Config.php
+
+		-
+			message: "#^Comparison operation \"\\>\" between int\\<1, max\\> and 0 is always true\\.$#"
+			count: 1
+			path: src/FileWatcher.php
+
+		-
+			message: "#^Result of \\|\\| is always true\\.$#"
+			count: 1
+			path: src/FileWatcher.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,14 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - src
+        - bin
+        - public
+    bootstrapFiles:
+        - vendor/autoload.php
+    excludePaths:
+        - vendor/*
+    treatPhpDocTypesAsCertain: false

--- a/src/AegisXmlParser.php
+++ b/src/AegisXmlParser.php
@@ -18,7 +18,7 @@ use NwsCad\Notifications\IntentResolver;
  *
  * @package NwsCad
  */
-class AegisXmlParser
+class AegisXmlParser implements ParserInterface
 {
     private PDO $db;
     private $logger;

--- a/src/Api/Response.php
+++ b/src/Api/Response.php
@@ -60,7 +60,7 @@ class Response
     /**
      * Send success response
      */
-    public static function success(mixed $data, string $message = null, int $statusCode = 200): void
+    public static function success(mixed $data, ?string $message = null, int $statusCode = 200): void
     {
         $response = [
             'success' => true,

--- a/src/FileWatcher.php
+++ b/src/FileWatcher.php
@@ -19,12 +19,14 @@ class FileWatcher
     private int $interval;
     private string $filePattern;
     private array $processedFiles = [];
-    private AegisXmlParser $parser;
+    private ParserInterface $parser;
     private $logger;
     private bool $running = true;
     private string $heartbeatPath;
     /** @var (callable():void)|null */
     private $onTick = null;
+    /** @var callable(int):void */
+    private $sleep;
 
     public function setOnTick(?callable $cb): void
     {
@@ -32,34 +34,65 @@ class FileWatcher
     }
 
     /**
-     * Constructor - Initialize file watcher
+     * Constructor - Initialize file watcher.
      *
-     * @throws Exception If database connection fails
+     * All parameters are optional test/injection seams. With no arguments the
+     * watcher behaves exactly as in production: configuration is read from the
+     * {@see Config} singleton, it blocks on {@see waitForDatabase()}, and it
+     * constructs a real {@see AegisXmlParser}. Passing a parser (and optional
+     * config/sleep overrides) bypasses the database wait so the file-handling
+     * logic can be unit-tested against real temp directories with no database.
+     *
+     * @param ParserInterface|null $parser    Injected ingest step; null → real AegisXmlParser (after DB wait).
+     * @param array<string,mixed>|null $config Override watcher config. Recognized keys:
+     *                                         'folder', 'interval', 'file_pattern', 'heartbeat_path'.
+     *                                         When provided, the Config singleton and DB wait are skipped.
+     * @param callable(int):void|null $sleep   Sleep seam (seconds → void); null → PHP sleep().
+     * @throws Exception If database connection fails (production path only).
      */
-    public function __construct()
-    {
-        $config = Config::getInstance();
-        $this->watchFolder = $config->get('watcher.folder');
-        $this->interval = $config->get('watcher.interval');
-        $this->filePattern = $config->get('watcher.file_pattern');
+    public function __construct(
+        ?ParserInterface $parser = null,
+        ?array $config = null,
+        ?callable $sleep = null
+    ) {
         $this->logger = Logger::getInstance();
-        $this->heartbeatPath = rtrim($config->get('paths.logs'), '/') . '/.watcher-heartbeat';
+        $this->sleep = $sleep ?? static function (int $seconds): void {
+            sleep($seconds);
+        };
 
-        $this->logger->info("Initializing File Watcher Service");
-        $this->logger->debug("Loading configuration from Config singleton");
-        $this->logger->debug("Watch Folder: {$this->watchFolder}");
-        $this->logger->debug("File Pattern: {$this->filePattern}");
-        $this->logger->debug("Check Interval: {$this->interval} seconds");
+        if ($config !== null) {
+            // Injection mode: caller supplies configuration and (optionally) a
+            // parser. The DB wait and Config singleton are skipped so unit
+            // tests need neither a database nor environment configuration.
+            $this->watchFolder = (string) $config['folder'];
+            $this->interval = (int) ($config['interval'] ?? 5);
+            $this->filePattern = (string) ($config['file_pattern'] ?? '*.xml');
+            $this->heartbeatPath = (string) ($config['heartbeat_path']
+                ?? rtrim($this->watchFolder, '/') . '/.watcher-heartbeat');
+            $this->parser = $parser ?? new AegisXmlParser();
+        } else {
+            $configSingleton = Config::getInstance();
+            $this->watchFolder = $configSingleton->get('watcher.folder');
+            $this->interval = $configSingleton->get('watcher.interval');
+            $this->filePattern = $configSingleton->get('watcher.file_pattern');
+            $this->heartbeatPath = rtrim($configSingleton->get('paths.logs'), '/') . '/.watcher-heartbeat';
 
-        // Wait for database BEFORE creating parser
-        $this->logger->info("Waiting for database connection...");
-        $this->logger->debug("Starting database connection wait loop");
-        $this->waitForDatabase();
-        
-        // Now create parser after database is ready
-        $this->logger->debug("Creating AegisXmlParser instance");
-        $this->parser = new AegisXmlParser();
-        $this->logger->debug("AegisXmlParser instance created successfully");
+            $this->logger->info("Initializing File Watcher Service");
+            $this->logger->debug("Loading configuration from Config singleton");
+            $this->logger->debug("Watch Folder: {$this->watchFolder}");
+            $this->logger->debug("File Pattern: {$this->filePattern}");
+            $this->logger->debug("Check Interval: {$this->interval} seconds");
+
+            // Wait for database BEFORE creating parser
+            $this->logger->info("Waiting for database connection...");
+            $this->logger->debug("Starting database connection wait loop");
+            $this->waitForDatabase();
+
+            // Now create parser after database is ready
+            $this->logger->debug("Creating AegisXmlParser instance");
+            $this->parser = $parser ?? new AegisXmlParser();
+            $this->logger->debug("AegisXmlParser instance created successfully");
+        }
 
         // Ensure watch folder exists
         if (!is_dir($this->watchFolder)) {
@@ -134,11 +167,11 @@ class FileWatcher
                 }
                 
                 $this->logger->debug("Sleeping for {$this->interval} seconds before next check...");
-                sleep($this->interval);
+                ($this->sleep)($this->interval);
             } catch (Exception $e) {
                 $this->logger->error("Error in watch loop: " . $e->getMessage());
                 $this->logger->error("Stack trace: " . $e->getTraceAsString());
-                sleep($this->interval);
+                ($this->sleep)($this->interval);
             }
         }
 
@@ -408,8 +441,8 @@ class FileWatcher
 
         $size1 = filesize($filePath);
         $this->logger->debug("  Initial file size: {$size1} bytes");
-        
-        sleep($checkInterval);
+
+        ($this->sleep)($checkInterval);
         clearstatcache(true, $filePath);
         $size2 = filesize($filePath);
         

--- a/src/FileWatcher.php
+++ b/src/FileWatcher.php
@@ -69,7 +69,17 @@ class FileWatcher
             $this->filePattern = (string) ($config['file_pattern'] ?? '*.xml');
             $this->heartbeatPath = (string) ($config['heartbeat_path']
                 ?? rtrim($this->watchFolder, '/') . '/.watcher-heartbeat');
-            $this->parser = $parser ?? new AegisXmlParser();
+            // A caller that supplies config but no parser still gets a real
+            // AegisXmlParser, which connects to the database on construction —
+            // so we must wait for the DB here too, exactly as the production
+            // path does. Only an injected parser (the unit-test case) is
+            // allowed to skip the wait.
+            if ($parser !== null) {
+                $this->parser = $parser;
+            } else {
+                $this->waitForDatabase();
+                $this->parser = new AegisXmlParser();
+            }
         } else {
             $configSingleton = Config::getInstance();
             $this->watchFolder = $configSingleton->get('watcher.folder');

--- a/src/ParserInterface.php
+++ b/src/ParserInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad;
+
+/**
+ * Contract for the XML ingest step that {@see FileWatcher} drives.
+ *
+ * Extracted so FileWatcher can be unit-tested with a fake parser (no database,
+ * no real XML) via the watcher's optional constructor seams. Production wiring
+ * is unchanged: {@see AegisXmlParser} is the only implementation and remains
+ * the default when no parser is injected.
+ */
+interface ParserInterface
+{
+    /**
+     * Process a single XML file.
+     *
+     * @param string $filePath Absolute path to the file to ingest.
+     * @return bool True on successful ingest, false on a handled failure.
+     */
+    public function processFile(string $filePath): bool;
+}

--- a/tests/Integration/ImporterCharacterizationTest.php
+++ b/tests/Integration/ImporterCharacterizationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NwsCad\Tests\Integration;
 
 use NwsCad\AegisXmlParser;
+use NwsCad\Api\DbHelper;
 use NwsCad\Database;
 use PHPUnit\Framework\TestCase;
 
@@ -15,6 +16,7 @@ use PHPUnit\Framework\TestCase;
  * unchanged, on both MySQL and PostgreSQL, before and after that refactor.
  *
  * @covers \NwsCad\AegisXmlParser
+ * @uses \NwsCad\Api\DbHelper
  * @uses \NwsCad\Config
  * @uses \NwsCad\Database
  * @uses \NwsCad\FilenameParser
@@ -34,7 +36,10 @@ class ImporterCharacterizationTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        if (!getenv('MYSQL_HOST')) {
+        // Driver-aware "is a DB configured?" gate: check the host of whichever
+        // driver DB_TYPE selects, not MYSQL_HOST unconditionally.
+        $hostVar = (getenv('DB_TYPE') ?: 'mysql') === 'pgsql' ? 'POSTGRES_HOST' : 'MYSQL_HOST';
+        if (!getenv($hostVar)) {
             $this->markTestSkipped('Database not configured for testing');
         }
         cleanTestDatabase();
@@ -72,6 +77,10 @@ class ImporterCharacterizationTest extends TestCase
 
     private function countFor(string $table, int $dbCallId): int
     {
+        // $table is always a hard-coded literal here, but validate it against
+        // the same identifier allowlist production SQL uses before interpolating
+        // (compliance: never interpolate an unvalidated identifier).
+        DbHelper::validateIdentifier($table, 'table');
         $db = Database::getConnection();
         $stmt = $db->prepare("SELECT COUNT(*) FROM {$table} WHERE call_id = ?");
         $stmt->execute([$dbCallId]);

--- a/tests/Integration/ImporterCharacterizationTest.php
+++ b/tests/Integration/ImporterCharacterizationTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Integration;
+
+use NwsCad\AegisXmlParser;
+use NwsCad\Database;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization of the full XML → 13-table ingest, asserting exact row
+ * contents after processing the fixtures in tests/fixtures/xml/. This is the
+ * behavior-preserving safety net for the importer refactor (#49): it must pass
+ * unchanged, on both MySQL and PostgreSQL, before and after that refactor.
+ *
+ * @covers \NwsCad\AegisXmlParser
+ * @uses \NwsCad\Config
+ * @uses \NwsCad\Database
+ * @uses \NwsCad\FilenameParser
+ * @uses \NwsCad\Logger
+ * @uses \NwsCad\Logging\RedactingProcessor
+ * @uses \NwsCad\Logging\SecretRegistry
+ * @uses \NwsCad\Api\Filtering\FilterOptionsCache
+ * @uses \NwsCad\Notifications\EventDispatcher
+ * @uses \NwsCad\Notifications\Events\CallProcessedEvent
+ * @uses \NwsCad\Notifications\Events\Intent
+ * @uses \NwsCad\Notifications\IntentResolver
+ */
+class ImporterCharacterizationTest extends TestCase
+{
+    private const FIXTURES = __DIR__ . '/../fixtures/xml';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!getenv('MYSQL_HOST')) {
+            $this->markTestSkipped('Database not configured for testing');
+        }
+        cleanTestDatabase();
+    }
+
+    private function ingest(string $fixture): void
+    {
+        $parser = new AegisXmlParser();
+        $ok = $parser->processFile(self::FIXTURES . '/' . $fixture);
+        $this->assertTrue($ok, "Fixture {$fixture} should ingest successfully");
+    }
+
+    private function callDbId(int $callId): int
+    {
+        $db = Database::getConnection();
+        $stmt = $db->prepare("SELECT id FROM calls WHERE call_id = ?");
+        $stmt->execute([$callId]);
+        $id = $stmt->fetchColumn();
+        $this->assertNotFalse($id, "calls row for call_id={$callId} must exist");
+        return (int) $id;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function oneRow(string $sql, int $bind): array
+    {
+        $db = Database::getConnection();
+        $stmt = $db->prepare($sql);
+        $stmt->execute([$bind]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $this->assertIsArray($row, "expected exactly one row for: {$sql}");
+        return $row;
+    }
+
+    private function countFor(string $table, int $dbCallId): int
+    {
+        $db = Database::getConnection();
+        $stmt = $db->prepare("SELECT COUNT(*) FROM {$table} WHERE call_id = ?");
+        $stmt->execute([$dbCallId]);
+        return (int) $stmt->fetchColumn();
+    }
+
+    public function testFullCallPopulatesEveryChildTableWithExactValues(): void
+    {
+        $this->ingest('full_call.xml');
+        $id = $this->callDbId(700001);
+
+        // calls
+        $call = $this->oneRow("SELECT * FROM calls WHERE id = ?", $id);
+        $this->assertSame('2026-700001', $call['call_number']);
+        $this->assertSame('911', $call['call_source']);
+        $this->assertSame('Ada Lovelace', $call['caller_name']);
+        $this->assertSame('555-0100', $call['caller_phone']);
+        $this->assertSame('Structure Fire', $call['nature_of_call']);
+        $this->assertSame('2026-02-01 08:15:00', $call['create_datetime']);
+        $this->assertSame(0, (int) $call['closed_flag']);
+        $this->assertSame(0, (int) $call['canceled_flag']);
+        $this->assertSame(0, (int) $call['reopened_flag']);
+        $this->assertSame(2, (int) $call['alarm_level']);
+
+        // agency_contexts
+        $ac = $this->oneRow("SELECT * FROM agency_contexts WHERE call_id = ?", $id);
+        $this->assertSame(1, $this->countFor('agency_contexts', $id));
+        $this->assertSame('Fire', $ac['agency_type']);
+        $this->assertSame('Structure Fire', $ac['call_type']);
+        $this->assertSame('High', $ac['priority']);
+        $this->assertSame('Active', $ac['status']);
+        $this->assertSame('48013', $ac['fdid']);
+        $this->assertSame(0, (int) $ac['closed_flag']);
+
+        // locations
+        $loc = $this->oneRow("SELECT * FROM locations WHERE call_id = ?", $id);
+        $this->assertSame(1, $this->countFor('locations', $id));
+        $this->assertSame('742 Evergreen Terrace', $loc['full_address']);
+        $this->assertSame('742', $loc['house_number']);
+        $this->assertSame('Evergreen', $loc['street_name']);
+        $this->assertSame('Terrace', $loc['street_type']);
+        $this->assertSame('Springfield', $loc['city']);
+        $this->assertSame('IL', $loc['state']);
+        $this->assertSame('62704', $loc['zip']);
+
+        // incidents
+        $inc = $this->oneRow("SELECT * FROM incidents WHERE call_id = ?", $id);
+        $this->assertSame(1, $this->countFor('incidents', $id));
+        $this->assertSame('INC-700001', $inc['incident_number']);
+        $this->assertSame('Fire', $inc['incident_type']);
+        $this->assertSame('City', $inc['jurisdiction']);
+        $this->assertSame('2026-02-01 08:15:30', $inc['create_datetime']);
+
+        // narratives
+        $nar = $this->oneRow("SELECT * FROM narratives WHERE call_id = ?", $id);
+        $this->assertSame(1, $this->countFor('narratives', $id));
+        $this->assertSame('2026-02-01 08:16:00', $nar['create_datetime']);
+        $this->assertSame('dispatcher01', $nar['create_user']);
+        $this->assertSame('Dispatch', $nar['narrative_type']);
+        $this->assertSame('Smoke showing from second floor.', $nar['text']);
+        $this->assertSame('None', $nar['restriction']);
+
+        // persons
+        $per = $this->oneRow("SELECT * FROM persons WHERE call_id = ?", $id);
+        $this->assertSame(1, $this->countFor('persons', $id));
+        $this->assertSame('Grace', $per['first_name']);
+        $this->assertSame('Hopper', $per['last_name']);
+        $this->assertSame('Witness', $per['role']);
+
+        // vehicles
+        $veh = $this->oneRow("SELECT * FROM vehicles WHERE call_id = ?", $id);
+        $this->assertSame(1, $this->countFor('vehicles', $id));
+        $this->assertSame('NAVY01', $veh['license_plate']);
+        $this->assertSame('IL', $veh['license_state']);
+        $this->assertSame('Ford', $veh['make']);
+        $this->assertSame('Bronco', $veh['model']);
+        $this->assertSame(2022, (int) $veh['year']);
+
+        // call_dispositions
+        $cd = $this->oneRow("SELECT * FROM call_dispositions WHERE call_id = ?", $id);
+        $this->assertSame(1, $this->countFor('call_dispositions', $id));
+        $this->assertSame('Fire Out', $cd['disposition_name']);
+        $this->assertSame(1, (int) $cd['count']);
+        $this->assertSame('2026-02-01 09:30:00', $cd['disposition_datetime']);
+
+        // units
+        $unit = $this->oneRow("SELECT * FROM units WHERE call_id = ?", $id);
+        $this->assertSame(1, $this->countFor('units', $id));
+        $unitId = (int) $unit['id'];
+        $this->assertSame('E12', $unit['unit_number']);
+        $this->assertSame('Engine', $unit['unit_type']);
+        $this->assertSame(1, (int) $unit['is_primary']);
+        $this->assertSame('City', $unit['jurisdiction']);
+        $this->assertSame('2026-02-01 08:15:10', $unit['assigned_datetime']);
+        $this->assertSame('2026-02-01 08:15:20', $unit['dispatch_datetime']);
+        $this->assertSame('2026-02-01 08:16:00', $unit['enroute_datetime']);
+        $this->assertSame('2026-02-01 08:20:00', $unit['arrive_datetime']);
+        $this->assertSame('2026-02-01 09:45:00', $unit['clear_datetime']);
+
+        // unit_personnel
+        $up = $this->oneRow("SELECT * FROM unit_personnel WHERE unit_id = ?", $unitId);
+        $this->assertSame('John', $up['first_name']);
+        $this->assertSame('Q', $up['middle_name']);
+        $this->assertSame('Firefighter', $up['last_name']);
+        $this->assertSame('FF-001', $up['id_number']);
+        $this->assertSame('1234', $up['shield_number']);
+        $this->assertSame(1, (int) $up['is_primary_officer']);
+        $this->assertSame('City', $up['jurisdiction']);
+
+        // unit_logs
+        $ul = $this->oneRow("SELECT * FROM unit_logs WHERE unit_id = ?", $unitId);
+        $this->assertSame('2026-02-01 08:20:00', $ul['log_datetime']);
+        $this->assertSame('OnScene', $ul['status']);
+        $this->assertSame('742 Evergreen Terrace', $ul['location']);
+
+        // unit_dispositions
+        $ud = $this->oneRow("SELECT * FROM unit_dispositions WHERE unit_id = ?", $unitId);
+        $this->assertSame('Extinguished', $ud['disposition_name']);
+        $this->assertSame('Fire fully extinguished', $ud['description']);
+        $this->assertSame(1, (int) $ud['count']);
+        $this->assertSame('2026-02-01 09:30:00', $ud['disposition_datetime']);
+    }
+
+    public function testMinimalCallInsertsOnlyTheCallRow(): void
+    {
+        $this->ingest('minimal_call.xml');
+        $id = $this->callDbId(700002);
+
+        $call = $this->oneRow("SELECT * FROM calls WHERE id = ?", $id);
+        $this->assertSame('2026-700002', $call['call_number']);
+        $this->assertSame('2026-02-01 10:00:00', $call['create_datetime']);
+        $this->assertSame(0, (int) $call['closed_flag']);
+
+        foreach (['agency_contexts', 'locations', 'incidents', 'narratives',
+                  'persons', 'vehicles', 'call_dispositions', 'units'] as $table) {
+            $this->assertSame(0, $this->countFor($table, $id),
+                "{$table} must have no rows for a minimal call");
+        }
+    }
+
+    public function testNilFieldsAreCoercedToNull(): void
+    {
+        $this->ingest('nil_fields.xml');
+        $id = $this->callDbId(700003);
+
+        $call = $this->oneRow("SELECT * FROM calls WHERE id = ?", $id);
+        $this->assertNull($call['call_source'], 'xsi:nil call source must be NULL');
+        $this->assertNull($call['caller_name'], 'xsi:nil caller name must be NULL');
+        $this->assertNull($call['close_datetime'], 'xsi:nil close datetime must be NULL');
+        $this->assertNull($call['alarm_level'], 'xsi:nil alarm level must be NULL');
+
+        $loc = $this->oneRow("SELECT * FROM locations WHERE call_id = ?", $id);
+        $this->assertSame('1 Unknown Way', $loc['full_address']);
+        $this->assertNull($loc['house_number'], 'xsi:nil house number must be NULL');
+        $this->assertNull($loc['zip'], 'xsi:nil zip must be NULL');
+
+        $ac = $this->oneRow("SELECT * FROM agency_contexts WHERE call_id = ?", $id);
+        $this->assertNull($ac['priority'], 'xsi:nil priority must be NULL');
+        $this->assertSame('Active', $ac['status']);
+    }
+
+    /**
+     * @return array<string,array{0:string,1:int}>
+     */
+    public static function bomProvider(): array
+    {
+        return [
+            'UTF-8 BOM'    => ['bom_utf8.xml', 700004],
+            'UTF-16BE BOM' => ['bom_utf16be.xml', 700005],
+            'UTF-16LE BOM' => ['bom_utf16le.xml', 700006],
+        ];
+    }
+
+    /**
+     * @dataProvider bomProvider
+     */
+    public function testBomPrefixedFilesIngestCleanly(string $fixture, int $callId): void
+    {
+        $this->ingest($fixture);
+        $call = $this->oneRow("SELECT * FROM calls WHERE call_id = ?", $callId);
+        $this->assertSame((string) $callId, (string) $call['call_id']);
+    }
+}

--- a/tests/Unit/DateTimeParsingCharacterizationTest.php
+++ b/tests/Unit/DateTimeParsingCharacterizationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Unit;
+
+use NwsCad\AegisXmlParser;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Characterization tests for AegisXmlParser::parseDateTime().
+ *
+ * These lock the *current* datetime-normalization behavior so the planned
+ * importer refactor (#49, which extracts a standalone DateTimeParser) can be
+ * verified as behavior-preserving. The golden outputs here were captured from
+ * the live method — do not "fix" them; if a value looks wrong, that is a bug
+ * to be addressed deliberately in the refactor, not silently in this test.
+ *
+ * parseDateTime() reads no instance state for any of these inputs (the only
+ * `$this` use is a logger->warning in the strtotime catch, which our inputs
+ * never trigger), so we exercise it on an object built without the
+ * DB-connecting constructor — keeping this a pure, driver-independent unit.
+ *
+ * @covers \NwsCad\AegisXmlParser
+ */
+class DateTimeParsingCharacterizationTest extends TestCase
+{
+    private static function invokeParseDateTime(?string $input): ?string
+    {
+        $parser = (new \ReflectionClass(AegisXmlParser::class))->newInstanceWithoutConstructor();
+        $method = new ReflectionMethod(AegisXmlParser::class, 'parseDateTime');
+        $method->setAccessible(true);
+
+        /** @var string|null $result */
+        $result = $method->invoke($parser, $input);
+        return $result;
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function explicitFormatProvider(): array
+    {
+        // Each of the eight ordered formats parseDateTime() tries, plus the
+        // strtotime() fallback, normalized to 'Y-m-d H:i:s'. Timezone offsets
+        // are preserved as wall-clock time (format() does not shift the value).
+        return [
+            'ISO 8601 with literal Z'          => ['2024-01-15T13:45:30Z', '2024-01-15 13:45:30'],
+            'ISO 8601 no timezone'             => ['2024-01-15T13:45:30', '2024-01-15 13:45:30'],
+            'ISO 8601 with microseconds'       => ['2024-01-15T13:45:30.123456', '2024-01-15 13:45:30'],
+            'ISO 8601 with offset'             => ['2024-01-15T13:45:30+05:00', '2024-01-15 13:45:30'],
+            'ISO 8601 microseconds + offset'   => ['2024-01-15T13:45:30.123456+05:00', '2024-01-15 13:45:30'],
+            'MySQL datetime'                   => ['2024-01-15 13:45:30', '2024-01-15 13:45:30'],
+            'US 24-hour'                       => ['01/15/2024 13:45:30', '2024-01-15 13:45:30'],
+            'US 12-hour with AM/PM'            => ['01/15/2024 01:45:30 PM', '2024-01-15 13:45:30'],
+            'strtotime fallback (long form)'   => ['January 15, 2024 1:45pm', '2024-01-15 13:45:00'],
+        ];
+    }
+
+    /**
+     * @dataProvider explicitFormatProvider
+     */
+    public function testNormalizesEachSupportedFormat(string $input, string $expected): void
+    {
+        $this->assertSame($expected, self::invokeParseDateTime($input));
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function nullProvider(): array
+    {
+        return [
+            'empty string'      => [''],
+            'literal nil'       => ['nil'],
+            'xsi nil attribute' => ['nil="true"'],
+            'unparseable junk'  => ['not a date'],
+        ];
+    }
+
+    /**
+     * @dataProvider nullProvider
+     */
+    public function testReturnsNullForEmptyNilAndUnparseable(string $input): void
+    {
+        $this->assertNull(self::invokeParseDateTime($input));
+    }
+
+    public function testNullInputReturnsNull(): void
+    {
+        $this->assertNull(self::invokeParseDateTime(null));
+    }
+
+    /**
+     * Overflowing components (month 13, day 45, hour 99...) are silently
+     * normalized by PHP's date arithmetic rather than rejected. The exact
+     * rolled-over value is PHP-version dependent and intentionally not pinned;
+     * we only lock the observable contract that such input yields a non-null
+     * normalized timestamp string (i.e. it does NOT fall through to null).
+     */
+    public function testOverflowingComponentsAreNormalizedNotRejected(): void
+    {
+        $result = self::invokeParseDateTime('2024-13-45T99:99:99');
+        $this->assertNotNull($result);
+        $this->assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+            $result
+        );
+    }
+}

--- a/tests/Unit/FileWatcherFileHandlingTest.php
+++ b/tests/Unit/FileWatcherFileHandlingTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Unit;
+
+use NwsCad\FileWatcher;
+use NwsCad\ParserInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * Unit coverage for FileWatcher's file-discovery and file-movement logic,
+ * exercised through the watcher's optional constructor-injection seams:
+ * a fake parser, an in-memory config, real temp directories, and a no-op
+ * sleep callable (so isFileStable() does not block for a real second).
+ *
+ * No database is touched — the injected-config path bypasses waitForDatabase()
+ * and the real AegisXmlParser entirely.
+ *
+ * @covers \NwsCad\FileWatcher
+ * @uses \NwsCad\FilenameParser
+ * @uses \NwsCad\Logger
+ * @uses \NwsCad\Logging\RedactingProcessor
+ * @uses \NwsCad\Logging\SecretRegistry
+ */
+class FileWatcherFileHandlingTest extends TestCase
+{
+    private string $watchDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->watchDir = sys_get_temp_dir() . '/fw_test_' . uniqid('', true);
+        mkdir($this->watchDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->watchDir);
+        parent::tearDown();
+    }
+
+    /**
+     * Build a watcher wired to a fake parser and this test's temp watch dir,
+     * with sleeps neutralized so file-stability checks are instant.
+     */
+    private function makeWatcher(RecordingParser $parser, string $pattern = '*.xml'): FileWatcher
+    {
+        return new FileWatcher(
+            $parser,
+            [
+                'folder' => $this->watchDir,
+                'interval' => 0,
+                'file_pattern' => $pattern,
+                'heartbeat_path' => $this->watchDir . '/.hb',
+            ],
+            static function (int $seconds): void {
+                // no-op: do not actually sleep during tests
+            }
+        );
+    }
+
+    private function writeFile(string $name, string $contents = "<xml/>"): string
+    {
+        $path = $this->watchDir . '/' . $name;
+        file_put_contents($path, $contents);
+        return $path;
+    }
+
+    private static function invoke(FileWatcher $w, string $method, mixed ...$args): mixed
+    {
+        $m = new ReflectionMethod(FileWatcher::class, $method);
+        $m->setAccessible(true);
+        return $m->invoke($w, ...$args);
+    }
+
+    public function testConvertGlobToRegexMatchesExtensionCaseInsensitively(): void
+    {
+        $w = $this->makeWatcher(new RecordingParser());
+        $regex = self::invoke($w, 'convertGlobToRegex', '*.xml');
+
+        $this->assertSame(1, preg_match($regex, 'call.xml'));
+        $this->assertSame(1, preg_match($regex, 'CALL.XML'));
+        $this->assertSame(0, preg_match($regex, 'call.txt'));
+    }
+
+    public function testScanDirectoryReturnsOnlyMatchingRootFiles(): void
+    {
+        $this->writeFile('a.xml');
+        $this->writeFile('b.xml');
+        $this->writeFile('ignore.txt');
+        mkdir($this->watchDir . '/processed');
+        $this->writeFile('processed/nested.xml');
+
+        $w = $this->makeWatcher(new RecordingParser());
+        /** @var array<int,string> $found */
+        $found = self::invoke($w, 'scanDirectory', $this->watchDir);
+
+        $names = array_map('basename', $found);
+        sort($names);
+        $this->assertSame(['a.xml', 'b.xml'], $names, 'subdirectories and non-matching files must be excluded');
+    }
+
+    public function testIsFileStableTrueForStaticFileAndFalseForMissing(): void
+    {
+        $path = $this->writeFile('stable.xml', 'content');
+        $w = $this->makeWatcher(new RecordingParser());
+
+        $this->assertTrue(self::invoke($w, 'isFileStable', $path, 0));
+        $this->assertFalse(self::invoke($w, 'isFileStable', $this->watchDir . '/nope.xml', 0));
+    }
+
+    public function testShouldProcessFileFalseOnceKeyIsAlreadyTracked(): void
+    {
+        $path = $this->writeFile('once.xml', 'content');
+        $w = $this->makeWatcher(new RecordingParser());
+
+        $this->assertTrue(self::invoke($w, 'shouldProcessFile', $path));
+
+        // Simulate the file having been processed this session.
+        $key = md5($path . filesize($path) . filemtime($path));
+        $prop = new ReflectionProperty(FileWatcher::class, 'processedFiles');
+        $prop->setAccessible(true);
+        $prop->setValue($w, [$key => time()]);
+
+        $this->assertFalse(self::invoke($w, 'shouldProcessFile', $path));
+    }
+
+    public function testSuccessfulParseMovesFileToProcessed(): void
+    {
+        $this->writeFile('100_2026010112000000.xml', '<xml/>');
+        $parser = new RecordingParser(true);
+        $w = $this->makeWatcher($parser);
+
+        self::invoke($w, 'checkForNewFiles');
+
+        $this->assertCount(1, $parser->processed, 'parser should have been invoked once');
+        $this->assertFileDoesNotExist($this->watchDir . '/100_2026010112000000.xml');
+        $this->assertFileExists($this->watchDir . '/processed/100_2026010112000000.xml');
+    }
+
+    public function testFailedParseMovesFileToFailed(): void
+    {
+        $this->writeFile('101_2026010112000001.xml', '<xml/>');
+        $parser = new RecordingParser(false);
+        $w = $this->makeWatcher($parser);
+
+        self::invoke($w, 'checkForNewFiles');
+
+        $this->assertCount(1, $parser->processed, 'parser must be invoked before the failure routing');
+        $this->assertFileDoesNotExist($this->watchDir . '/101_2026010112000001.xml');
+        $this->assertFileExists($this->watchDir . '/failed/101_2026010112000001.xml');
+    }
+
+    public function testUnparseableFilenameMovedToFailedWithoutParsing(): void
+    {
+        // FilenameParser treats names containing '~' as unparseable.
+        $this->writeFile('bad~name.xml', '<xml/>');
+        $parser = new RecordingParser(true);
+        $w = $this->makeWatcher($parser);
+
+        self::invoke($w, 'checkForNewFiles');
+
+        $this->assertSame([], $parser->processed, 'unparseable files must not reach the parser');
+        $this->assertFileExists($this->watchDir . '/failed/bad~name.xml');
+    }
+
+    public function testGetUniqueFilenameSuffixesOnCollision(): void
+    {
+        mkdir($this->watchDir . '/processed');
+        file_put_contents($this->watchDir . '/processed/x.xml', 'a');
+        $w = $this->makeWatcher(new RecordingParser());
+
+        $unique = self::invoke($w, 'getUniqueFilename', $this->watchDir . '/processed/x.xml');
+        $this->assertSame($this->watchDir . '/processed/x_1.xml', $unique);
+    }
+
+    public function testHandleSignalStopsTheWatcher(): void
+    {
+        $w = $this->makeWatcher(new RecordingParser());
+        $running = new ReflectionProperty(FileWatcher::class, 'running');
+        $running->setAccessible(true);
+
+        $this->assertTrue($running->getValue($w));
+        $w->handleSignal(15);
+        $this->assertFalse($running->getValue($w), 'a shutdown signal must clear the running flag');
+    }
+
+    public function testProcessedFileMemoryIsPrunedToOneThousand(): void
+    {
+        $this->writeFile('200_2026010112000000.xml', '<xml/>');
+        $parser = new RecordingParser(true);
+        $w = $this->makeWatcher($parser);
+
+        // Pre-load 1500 stale tracking keys; checkForNewFiles() prunes to 1000.
+        $prop = new ReflectionProperty(FileWatcher::class, 'processedFiles');
+        $prop->setAccessible(true);
+        $seed = [];
+        for ($i = 0; $i < 1500; $i++) {
+            $seed['k' . $i] = $i;
+        }
+        $prop->setValue($w, $seed);
+
+        self::invoke($w, 'checkForNewFiles');
+
+        $this->assertLessThanOrEqual(1000, count($prop->getValue($w)),
+            'in-memory processed-file tracking must be capped');
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->rrmdir($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+}
+
+/**
+ * Minimal ParserInterface test double: records the files it is asked to
+ * process and returns a fixed success/failure result.
+ */
+final class RecordingParser implements ParserInterface
+{
+    /** @var array<int,string> */
+    public array $processed = [];
+
+    public function __construct(private bool $result = true)
+    {
+    }
+
+    public function processFile(string $filePath): bool
+    {
+        $this->processed[] = $filePath;
+        return $this->result;
+    }
+}

--- a/tests/Unit/FileWatcherFileHandlingTest.php
+++ b/tests/Unit/FileWatcherFileHandlingTest.php
@@ -20,6 +20,7 @@ use ReflectionProperty;
  * and the real AegisXmlParser entirely.
  *
  * @covers \NwsCad\FileWatcher
+ * @uses \NwsCad\Config
  * @uses \NwsCad\FilenameParser
  * @uses \NwsCad\Logger
  * @uses \NwsCad\Logging\RedactingProcessor

--- a/tests/Unit/XmlLoadGuardsTest.php
+++ b/tests/Unit/XmlLoadGuardsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NwsCad\Tests\Unit;
+
+use NwsCad\AegisXmlParser;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use ReflectionClass;
+use ReflectionMethod;
+use SimpleXMLElement;
+
+/**
+ * Characterizes AegisXmlParser::loadXmlFile()'s pre-parse guards — the
+ * XML_MAX_BYTES size cap and the DOCTYPE (XXE) rejection — without a database.
+ * loadXmlFile() only touches the filesystem, libxml, and the logger, so we run
+ * it on a constructor-less instance with a NullLogger injected via reflection.
+ *
+ * Covers the "oversized file" and XXE fixture cases from #48 without committing
+ * a multi-megabyte artifact to the repo (the oversized input is generated at
+ * runtime against a lowered XML_MAX_BYTES cap).
+ *
+ * @covers \NwsCad\AegisXmlParser
+ */
+class XmlLoadGuardsTest extends TestCase
+{
+    private ?string $originalMaxBytes = null;
+    /** @var array<int,string> */
+    private array $tmpFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalMaxBytes = getenv('XML_MAX_BYTES') ?: null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalMaxBytes === null) {
+            putenv('XML_MAX_BYTES');
+        } else {
+            putenv('XML_MAX_BYTES=' . $this->originalMaxBytes);
+        }
+        foreach ($this->tmpFiles as $f) {
+            @unlink($f);
+        }
+        parent::tearDown();
+    }
+
+    private function writeTmp(string $contents): string
+    {
+        $path = sys_get_temp_dir() . '/xmlguard_' . uniqid('', true) . '.xml';
+        file_put_contents($path, $contents);
+        $this->tmpFiles[] = $path;
+        return $path;
+    }
+
+    private function loadXml(string $path): SimpleXMLElement|false
+    {
+        $rc = new ReflectionClass(AegisXmlParser::class);
+        $obj = $rc->newInstanceWithoutConstructor();
+        $logger = $rc->getProperty('logger');
+        $logger->setAccessible(true);
+        $logger->setValue($obj, new NullLogger());
+
+        $m = new ReflectionMethod(AegisXmlParser::class, 'loadXmlFile');
+        $m->setAccessible(true);
+        /** @var SimpleXMLElement|false $result */
+        $result = $m->invoke($obj, $path);
+        return $result;
+    }
+
+    public function testOversizedFileIsRejected(): void
+    {
+        putenv('XML_MAX_BYTES=1024');
+        $body = '<?xml version="1.0" encoding="UTF-8"?><CallExport>'
+            . str_repeat('<Pad>x</Pad>', 500) // well over 1 KiB
+            . '</CallExport>';
+        $path = $this->writeTmp($body);
+        $this->assertGreaterThan(1024, strlen($body), 'precondition: input exceeds the cap');
+
+        $this->assertFalse($this->loadXml($path), 'file over XML_MAX_BYTES must be rejected');
+    }
+
+    public function testFileWithinCapLoads(): void
+    {
+        putenv('XML_MAX_BYTES=1048576');
+        $path = $this->writeTmp(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<CallExport xmlns="http://www.newworldsystems.com/Aegis/CAD/Peripheral/CallExport/2011/02">'
+            . '<CallId>1</CallId></CallExport>'
+        );
+        $this->assertInstanceOf(SimpleXMLElement::class, $this->loadXml($path));
+    }
+
+    public function testDoctypeDeclarationIsRejected(): void
+    {
+        $path = $this->writeTmp(
+            "<?xml version=\"1.0\"?>\n"
+            . "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>\n"
+            . '<CallExport><CallId>&xxe;</CallId></CallExport>'
+        );
+        $this->assertFalse($this->loadXml($path), 'a DOCTYPE declaration must be rejected outright');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,30 +31,54 @@ $_ENV['APP_DEBUG'] = 'false';
 $_ENV['LOG_LEVEL'] = 'error';
 
 // CRITICAL SAFETY: redirect ALL DB access during tests to a dedicated test
-// database. cleanTestDatabase() does a sweeping DELETE across 15 tables, so
-// a connection to production destroys live CAD data on every test run.
+// database. cleanTestDatabase() truncates every row in every table, so a
+// connection to production destroys live CAD data on every test run.
+//
+// Only the driver selected by DB_TYPE is redirected/guarded — the other
+// driver's env may carry unrelated defaults (phpunit.xml sets both), and
+// enforcing its guard would spuriously abort a single-driver run.
 //
 // 1. Remember the original (production) database name so the guard can
 //    refuse to run if anything later tries to point us back at it.
-// 2. Override MYSQL_DATABASE in this process to the test database. Both
+// 2. Override the active driver's database env to the test database. Both
 //    Database::getConnection() (used by controllers under test) and
 //    getTestDbConnection() (used by cleanTestDatabase) read this env, so
 //    both will target nws_cad_test.
-$originalDb = $_ENV['MYSQL_DATABASE'] ?? getenv('MYSQL_DATABASE') ?: '';
-$_ENV['MYSQL_PRODUCTION_DATABASE'] = $originalDb;
-putenv('MYSQL_PRODUCTION_DATABASE=' . $originalDb);
+$dbType = $_ENV['DB_TYPE'] ?? getenv('DB_TYPE') ?: 'mysql';
 
-$testDbName = $_ENV['MYSQL_TEST_DATABASE'] ?? getenv('MYSQL_TEST_DATABASE') ?: 'nws_cad_test';
-if ($originalDb !== '' && $testDbName === $originalDb) {
-    throw new RuntimeException(
-        "Refusing to run tests: MYSQL_TEST_DATABASE ({$testDbName}) equals MYSQL_DATABASE ({$originalDb}). " .
-        "Tests truncate every row in 15 tables; pointing them at production destroys live CAD data. " .
-        "Set MYSQL_TEST_DATABASE to a different database name (e.g. nws_cad_test) and ensure it exists."
-    );
+if ($dbType === 'pgsql') {
+    $originalPgDb = $_ENV['POSTGRES_DB'] ?? getenv('POSTGRES_DB') ?: '';
+    $_ENV['POSTGRES_PRODUCTION_DATABASE'] = $originalPgDb;
+    putenv('POSTGRES_PRODUCTION_DATABASE=' . $originalPgDb);
+
+    $pgTestDbName = $_ENV['POSTGRES_TEST_DATABASE'] ?? getenv('POSTGRES_TEST_DATABASE') ?: 'nws_cad_test';
+    if ($originalPgDb !== '' && $pgTestDbName === $originalPgDb) {
+        throw new RuntimeException(
+            "Refusing to run tests: POSTGRES_TEST_DATABASE ({$pgTestDbName}) equals POSTGRES_DB ({$originalPgDb}). " .
+            "Tests truncate every row in every table; pointing them at production destroys live CAD data. " .
+            "Set POSTGRES_TEST_DATABASE to a different database name (e.g. nws_cad_test) and ensure it exists."
+        );
+    }
+
+    $_ENV['POSTGRES_DB'] = $pgTestDbName;
+    putenv('POSTGRES_DB=' . $pgTestDbName);
+} else {
+    $originalDb = $_ENV['MYSQL_DATABASE'] ?? getenv('MYSQL_DATABASE') ?: '';
+    $_ENV['MYSQL_PRODUCTION_DATABASE'] = $originalDb;
+    putenv('MYSQL_PRODUCTION_DATABASE=' . $originalDb);
+
+    $testDbName = $_ENV['MYSQL_TEST_DATABASE'] ?? getenv('MYSQL_TEST_DATABASE') ?: 'nws_cad_test';
+    if ($originalDb !== '' && $testDbName === $originalDb) {
+        throw new RuntimeException(
+            "Refusing to run tests: MYSQL_TEST_DATABASE ({$testDbName}) equals MYSQL_DATABASE ({$originalDb}). " .
+            "Tests truncate every row in 15 tables; pointing them at production destroys live CAD data. " .
+            "Set MYSQL_TEST_DATABASE to a different database name (e.g. nws_cad_test) and ensure it exists."
+        );
+    }
+
+    $_ENV['MYSQL_DATABASE'] = $testDbName;
+    putenv('MYSQL_DATABASE=' . $testDbName);
 }
-
-$_ENV['MYSQL_DATABASE'] = $testDbName;
-putenv('MYSQL_DATABASE=' . $testDbName);
 
 // Helper function to create test database connection.
 //
@@ -63,6 +87,28 @@ putenv('MYSQL_DATABASE=' . $testDbName);
 // the saved MYSQL_PRODUCTION_DATABASE.
 function getTestDbConnection(): PDO
 {
+    $dbType = $_ENV['DB_TYPE'] ?? getenv('DB_TYPE') ?: 'mysql';
+
+    if ($dbType === 'pgsql') {
+        $dsn = sprintf(
+            "pgsql:host=%s;port=%s;dbname=%s",
+            $_ENV['POSTGRES_HOST'] ?? '127.0.0.1',
+            $_ENV['POSTGRES_PORT'] ?? '5432',
+            $_ENV['POSTGRES_DB'],
+        );
+
+        return new PDO(
+            $dsn,
+            $_ENV['POSTGRES_TEST_USER'] ?? getenv('POSTGRES_TEST_USER') ?: ($_ENV['POSTGRES_USER'] ?? 'test_user'),
+            $_ENV['POSTGRES_TEST_PASSWORD'] ?? getenv('POSTGRES_TEST_PASSWORD') ?: ($_ENV['POSTGRES_PASSWORD'] ?? 'test_pass'),
+            [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES => false,
+            ]
+        );
+    }
+
     $dsn = sprintf(
         "mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4",
         $_ENV['MYSQL_HOST'] ?? '127.0.0.1',
@@ -93,18 +139,28 @@ function getTestDbConnection(): PDO
 // without fighting the FK graph; we restore the FK check before returning.
 function cleanTestDatabase(): void
 {
+    $dbType = $_ENV['DB_TYPE'] ?? getenv('DB_TYPE') ?: 'mysql';
+    $tables = [
+        'notification_outbox',
+        'notification_send_log',
+        'notification_channels',
+        'unit_dispositions', 'unit_logs', 'unit_personnel', 'units',
+        'call_dispositions', 'vehicles', 'persons', 'narratives',
+        'incidents', 'locations', 'agency_contexts', 'calls', 'processed_files'
+    ];
+
     try {
         $pdo = getTestDbConnection();
-        $tables = [
-            'notification_outbox',
-            'notification_send_log',
-            'notification_channels',
-            'unit_dispositions', 'unit_logs', 'unit_personnel', 'units',
-            'call_dispositions', 'vehicles', 'persons', 'narratives',
-            'incidents', 'locations', 'agency_contexts', 'calls', 'processed_files'
-        ];
 
-        // DELETE first (FK ON DELETE CASCADE handles children), then reset
+        if ($dbType === 'pgsql') {
+            // TRUNCATE ... RESTART IDENTITY CASCADE clears rows, resets the
+            // identity/serial sequences (integration tests hard-code PKs), and
+            // walks the FK graph in one statement.
+            $pdo->exec('TRUNCATE ' . implode(', ', $tables) . ' RESTART IDENTITY CASCADE');
+            return;
+        }
+
+        // MySQL: DELETE first (FK ON DELETE CASCADE handles children), then reset
         // AUTO_INCREMENT separately. We avoid TRUNCATE here because some MySQL
         // versions reject it on a parent table referenced by a FK even with
         // FOREIGN_KEY_CHECKS=0.

--- a/tests/fixtures/xml/README.md
+++ b/tests/fixtures/xml/README.md
@@ -1,0 +1,23 @@
+# XML ingest fixtures
+
+Canonical Aegis CAD `CallExport` documents used by the importer characterization
+and edge-case tests (issue #48). Keeping them as real files (rather than inline
+heredocs) lets the same inputs feed both MySQL and PostgreSQL CI jobs and gives
+the planned importer refactor (#49) a stable, reviewable corpus.
+
+| Fixture | CallId | Purpose |
+|---|---|---|
+| `full_call.xml` | 700001 | Every child table populated (agency context, location, incident, narrative, person, vehicle, call disposition, unit + personnel + unit log + unit disposition). The row-content characterization baseline. |
+| `minimal_call.xml` | 700002 | Only the required call fields — no child collections. Locks the "sparse call" path. |
+| `nil_fields.xml` | 700003 | `xsi:nil="true"` on optional scalars (call source, caller, alarm level, house number, zip, …) to lock null-coercion behavior. |
+| `bom_utf8.xml` | 700004 | Leading UTF-8 BOM (`EF BB BF`) — exercises `stripBOM()`. |
+| `bom_utf16be.xml` | 700005 | Leading UTF-16 BE BOM (`FE FF`). Body stays ASCII so only the BOM branch is under test. |
+| `bom_utf16le.xml` | 700006 | Leading UTF-16 LE BOM (`FF FE`), same rationale. |
+
+All CallIds are in the `7000xx` range to avoid collisions with the hard-coded
+primary keys other integration tests rely on.
+
+Reopen and stale-ordering scenarios are driven by the tests themselves (same
+`CallId` ingested twice under different `{call_number}_{timestamp}.xml`
+filenames), not by separate fixture files, because those behaviors depend on
+processing order and filename recency rather than document content.

--- a/tests/fixtures/xml/bom_utf16be.xml
+++ b/tests/fixtures/xml/bom_utf16be.xml
@@ -1,0 +1,8 @@
+þÿ<?xml version="1.0" encoding="UTF-8"?>
+<CallExport xmlns="http://www.newworldsystems.com/Aegis/CAD/Peripheral/CallExport/2011/02">
+    <CallId>700005</CallId>
+    <CallNumber>2026-700005</CallNumber>
+    <CreateDateTime>2026-02-01T10:00:00</CreateDateTime>
+    <ClosedFlag>false</ClosedFlag>
+    <CanceledFlag>false</CanceledFlag>
+</CallExport>

--- a/tests/fixtures/xml/bom_utf16le.xml
+++ b/tests/fixtures/xml/bom_utf16le.xml
@@ -1,0 +1,8 @@
+ÿþ<?xml version="1.0" encoding="UTF-8"?>
+<CallExport xmlns="http://www.newworldsystems.com/Aegis/CAD/Peripheral/CallExport/2011/02">
+    <CallId>700006</CallId>
+    <CallNumber>2026-700006</CallNumber>
+    <CreateDateTime>2026-02-01T10:00:00</CreateDateTime>
+    <ClosedFlag>false</ClosedFlag>
+    <CanceledFlag>false</CanceledFlag>
+</CallExport>

--- a/tests/fixtures/xml/bom_utf8.xml
+++ b/tests/fixtures/xml/bom_utf8.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<CallExport xmlns="http://www.newworldsystems.com/Aegis/CAD/Peripheral/CallExport/2011/02">
+    <CallId>700004</CallId>
+    <CallNumber>2026-700004</CallNumber>
+    <CreateDateTime>2026-02-01T10:00:00</CreateDateTime>
+    <ClosedFlag>false</ClosedFlag>
+    <CanceledFlag>false</CanceledFlag>
+</CallExport>

--- a/tests/fixtures/xml/full_call.xml
+++ b/tests/fixtures/xml/full_call.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CallExport xmlns="http://www.newworldsystems.com/Aegis/CAD/Peripheral/CallExport/2011/02">
+    <CallId>700001</CallId>
+    <CallNumber>2026-700001</CallNumber>
+    <CallSource>911</CallSource>
+    <CallerName>Ada Lovelace</CallerName>
+    <CallerPhone>555-0100</CallerPhone>
+    <NatureOfCall>Structure Fire</NatureOfCall>
+    <CreateDateTime>2026-02-01T08:15:00</CreateDateTime>
+    <ClosedFlag>false</ClosedFlag>
+    <CanceledFlag>false</CanceledFlag>
+    <AlarmLevel>2</AlarmLevel>
+    <AgencyContexts>
+        <AgencyContext>
+            <AgencyType>Fire</AgencyType>
+            <CallType>Structure Fire</CallType>
+            <Priority>High</Priority>
+            <Status>Active</Status>
+            <FDID>48013</FDID>
+            <CreatedDateTime>2026-02-01T08:15:00</CreatedDateTime>
+            <ClosedFlag>false</ClosedFlag>
+            <CanceledFlag>false</CanceledFlag>
+        </AgencyContext>
+    </AgencyContexts>
+    <Location>
+        <FullAddress>742 Evergreen Terrace</FullAddress>
+        <HouseNumber>742</HouseNumber>
+        <StreetName>Evergreen</StreetName>
+        <StreetType>Terrace</StreetType>
+        <City>Springfield</City>
+        <State>IL</State>
+        <Zip>62704</Zip>
+    </Location>
+    <Incidents>
+        <Incident>
+            <Number>INC-700001</Number>
+            <Type>Fire</Type>
+            <Jurisdiction>City</Jurisdiction>
+            <CreateDateTime>2026-02-01T08:15:30</CreateDateTime>
+        </Incident>
+    </Incidents>
+    <Narratives>
+        <Narrative>
+            <CreateDateTime>2026-02-01T08:16:00</CreateDateTime>
+            <CreateUser>dispatcher01</CreateUser>
+            <Type>Dispatch</Type>
+            <Text>Smoke showing from second floor.</Text>
+            <Restriction>None</Restriction>
+        </Narrative>
+    </Narratives>
+    <Persons>
+        <Person>
+            <FirstName>Grace</FirstName>
+            <LastName>Hopper</LastName>
+            <Role>Witness</Role>
+        </Person>
+    </Persons>
+    <Vehicles>
+        <Vehicle>
+            <LicensePlate>NAVY01</LicensePlate>
+            <LicenseState>IL</LicenseState>
+            <Make>Ford</Make>
+            <Model>Bronco</Model>
+            <Year>2022</Year>
+        </Vehicle>
+    </Vehicles>
+    <Dispositions>
+        <CallDisposition>
+            <Name>Fire Out</Name>
+            <Count>1</Count>
+            <DateTime>2026-02-01T09:30:00</DateTime>
+        </CallDisposition>
+    </Dispositions>
+    <AssignedUnits>
+        <Unit>
+            <UnitNumber>E12</UnitNumber>
+            <Type>Engine</Type>
+            <IsPrimary>true</IsPrimary>
+            <Jurisdiction>City</Jurisdiction>
+            <AssignedDateTime>2026-02-01T08:15:10</AssignedDateTime>
+            <DispatchDateTime>2026-02-01T08:15:20</DispatchDateTime>
+            <EnrouteDateTime>2026-02-01T08:16:00</EnrouteDateTime>
+            <ArriveDateTime>2026-02-01T08:20:00</ArriveDateTime>
+            <ClearDateTime>2026-02-01T09:45:00</ClearDateTime>
+            <Personnel>
+                <UnitPersonnel>
+                    <FirstName>John</FirstName>
+                    <MiddleName>Q</MiddleName>
+                    <LastName>Firefighter</LastName>
+                    <IDNumber>FF-001</IDNumber>
+                    <ShieldNumber>1234</ShieldNumber>
+                    <IsPrimaryOfficer>true</IsPrimaryOfficer>
+                    <Jurisdiction>City</Jurisdiction>
+                </UnitPersonnel>
+            </Personnel>
+            <UnitLogs>
+                <UnitLog>
+                    <DateTime>2026-02-01T08:20:00</DateTime>
+                    <Status>OnScene</Status>
+                    <Location>742 Evergreen Terrace</Location>
+                </UnitLog>
+            </UnitLogs>
+            <Dispositions>
+                <Disposition>
+                    <Name>Extinguished</Name>
+                    <Description>Fire fully extinguished</Description>
+                    <Count>1</Count>
+                    <DateTime>2026-02-01T09:30:00</DateTime>
+                </Disposition>
+            </Dispositions>
+        </Unit>
+    </AssignedUnits>
+</CallExport>

--- a/tests/fixtures/xml/minimal_call.xml
+++ b/tests/fixtures/xml/minimal_call.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CallExport xmlns="http://www.newworldsystems.com/Aegis/CAD/Peripheral/CallExport/2011/02">
+    <CallId>700002</CallId>
+    <CallNumber>2026-700002</CallNumber>
+    <CreateDateTime>2026-02-01T10:00:00</CreateDateTime>
+    <ClosedFlag>false</ClosedFlag>
+    <CanceledFlag>false</CanceledFlag>
+</CallExport>

--- a/tests/fixtures/xml/nil_fields.xml
+++ b/tests/fixtures/xml/nil_fields.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CallExport xmlns="http://www.newworldsystems.com/Aegis/CAD/Peripheral/CallExport/2011/02"
+            xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+    <CallId>700003</CallId>
+    <CallNumber>2026-700003</CallNumber>
+    <CallSource i:nil="true"/>
+    <CallerName i:nil="true"/>
+    <NatureOfCall>Unknown</NatureOfCall>
+    <CreateDateTime>2026-02-01T11:00:00</CreateDateTime>
+    <CloseDateTime i:nil="true"/>
+    <ClosedFlag>false</ClosedFlag>
+    <CanceledFlag>false</CanceledFlag>
+    <AlarmLevel i:nil="true"/>
+    <AgencyContexts>
+        <AgencyContext>
+            <AgencyType>Police</AgencyType>
+            <CallType>Welfare Check</CallType>
+            <Priority i:nil="true"/>
+            <Status>Active</Status>
+            <ClosedFlag>false</ClosedFlag>
+            <CanceledFlag>false</CanceledFlag>
+        </AgencyContext>
+    </AgencyContexts>
+    <Location>
+        <FullAddress>1 Unknown Way</FullAddress>
+        <HouseNumber i:nil="true"/>
+        <City>Springfield</City>
+        <State>IL</State>
+        <Zip i:nil="true"/>
+    </Location>
+</CallExport>


### PR DESCRIPTION
Closes #48.

Test-infrastructure hardening and the importer characterization safety net that unblocks the #49 refactor. Behavior-preserving: the only production code touched is FileWatcher gaining optional, default-null constructor seams (`watcher.php` unchanged) and `AegisXmlParser` implementing a new `ParserInterface`.

## What's here
- **PHPStan level 5** over `src/`/`bin/`/`public/` with a 6-finding baseline and a `composer phpstan` script. Fixed one real finding (`Response::success()` implicit-nullable param).
- **`parseDateTime()` characterization** — 15 cases (8 formats + strtotime fallback + nil/empty/null), golden values captured from the live method.
- **FileWatcher unit tests** — 10 tests via constructor-injection seams (fake parser, in-memory config, no-op sleep) against real temp dirs: glob→regex, directory scan, stability, session dedupe, success→processed / failure→failed routing, unparseable→failed, unique-name collision, signal shutdown, memory prune. No DB.
- **XML fixtures library** — 6 canonical `CallExport` docs (full call, minimal, `xsi:nil`, UTF-8/UTF-16BE/UTF-16LE BOM) + README.
- **Importer characterization suite** — ingests the corpus and asserts exact row contents across all 13 child tables, plus minimal-call emptiness, nil→NULL coercion, and BOM ingestion. This is the safety net #49 must keep green on both drivers.
- **Driver-aware `tests/bootstrap.php`** — `DB_TYPE`-gated test-DB redirect + safety guard, `POSTGRES_TEST_DATABASE` support, pgsql DSN, and `TRUNCATE ... RESTART IDENTITY CASCADE` reset.
- **Non-blocking PostgreSQL CI job** (`postgres:16`, `continue-on-error: true`) that loads the pgsql schema into `nws_cad_test` and runs the suites with `DB_TYPE=pgsql`.

## Verification (local, both drivers)
Ran in a container built from the project Dockerfile (pdo_mysql/pdo_pgsql/pcov) against real MySQL 8.0 and PostgreSQL 16:
- MySQL, clean cache: **Unit 290/290, Integration 180/180, Security 61/61** green.
- Importer characterization: **green on MySQL and PostgreSQL** (125 assertions each).
- New test classes pass under pcov (strict coverage metadata satisfied).

The broader Postgres suite still has pre-existing pgsql gaps in other code (unrelated to this PR) — hence the Postgres job is intentionally non-blocking until brought green incrementally.

Doc/CI pcov-vs-xdebug consistency (checklist item 6) was already correct in `CLAUDE.md`, so no change was needed there.
