### PR TITLE
perf(db,api): composite indexes, N+1 consolidation, outbox claim + targeted cache

### DIFF
--- a/database/migrations/2026-07-11-outbox-next-attempt-not-null.pgsql.sql
+++ b/database/migrations/2026-07-11-outbox-next-attempt-not-null.pgsql.sql
@@ -1,0 +1,8 @@
+-- database/migrations/2026-07-11-outbox-next-attempt-not-null.pgsql.sql
+-- Perf (#50): make notification_outbox.next_attempt_at NOT NULL with a default
+-- (PostgreSQL). Idempotent: safe to re-run.
+
+UPDATE notification_outbox SET next_attempt_at = CURRENT_TIMESTAMP WHERE next_attempt_at IS NULL;
+
+ALTER TABLE notification_outbox ALTER COLUMN next_attempt_at SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE notification_outbox ALTER COLUMN next_attempt_at SET NOT NULL;

--- a/database/migrations/2026-07-11-outbox-next-attempt-not-null.sql
+++ b/database/migrations/2026-07-11-outbox-next-attempt-not-null.sql
@@ -1,0 +1,12 @@
+-- database/migrations/2026-07-11-outbox-next-attempt-not-null.sql
+-- Perf (#50): make notification_outbox.next_attempt_at NOT NULL with a default,
+-- so the claim query can drop its `next_attempt_at IS NULL OR ...` branch and
+-- let the (status, next_attempt_at) index do a clean range seek.
+-- Idempotent: safe to re-run.
+
+-- A NULL next_attempt_at previously meant "eligible immediately"; backfill those
+-- to now so they stay eligible under the new `next_attempt_at <= ?` predicate.
+UPDATE notification_outbox SET next_attempt_at = CURRENT_TIMESTAMP WHERE next_attempt_at IS NULL;
+
+ALTER TABLE notification_outbox
+    MODIFY COLUMN next_attempt_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/database/migrations/2026-07-11-perf-composite-indexes.pgsql.sql
+++ b/database/migrations/2026-07-11-perf-composite-indexes.pgsql.sql
@@ -1,0 +1,9 @@
+-- database/migrations/2026-07-11-perf-composite-indexes.pgsql.sql
+-- Perf (#50): composite indexes for hot read paths (PostgreSQL). Idempotent.
+--   narratives(call_id, create_datetime)          — call narratives endpoint
+--   unit_logs(unit_id, log_datetime)              — unit logs endpoint
+--   notification_send_log(call_id, created_at)    — per-call send-log lookups
+
+CREATE INDEX IF NOT EXISTS idx_narratives_call_created ON narratives(call_id, create_datetime);
+CREATE INDEX IF NOT EXISTS idx_unit_logs_unit_log ON unit_logs(unit_id, log_datetime);
+CREATE INDEX IF NOT EXISTS idx_send_log_call_created ON notification_send_log(call_id, created_at);

--- a/database/migrations/2026-07-11-perf-composite-indexes.sql
+++ b/database/migrations/2026-07-11-perf-composite-indexes.sql
@@ -1,0 +1,23 @@
+-- database/migrations/2026-07-11-perf-composite-indexes.sql
+-- Perf (#50): composite indexes for hot read paths. Idempotent: safe to re-run.
+--   narratives(call_id, create_datetime)          — call narratives endpoint
+--   unit_logs(unit_id, log_datetime)              — unit logs endpoint
+--   notification_send_log(call_id, created_at)    — per-call send-log lookups
+
+DELIMITER $$
+DROP PROCEDURE IF EXISTS ensure_index $$
+CREATE PROCEDURE ensure_index(IN tbl VARCHAR(64), IN idx VARCHAR(64), IN cols VARCHAR(255))
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = tbl AND INDEX_NAME = idx) THEN
+        SET @s := CONCAT('CREATE INDEX ', idx, ' ON ', tbl, ' (', cols, ')');
+        PREPARE stmt FROM @s; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+    END IF;
+END $$
+DELIMITER ;
+
+CALL ensure_index('narratives', 'idx_narratives_call_created', 'call_id, create_datetime');
+CALL ensure_index('unit_logs', 'idx_unit_logs_unit_log', 'unit_id, log_datetime');
+CALL ensure_index('notification_send_log', 'idx_send_log_call_created', 'call_id, created_at');
+
+DROP PROCEDURE ensure_index;

--- a/database/mysql/init.sql
+++ b/database/mysql/init.sql
@@ -581,7 +581,7 @@ CREATE TABLE IF NOT EXISTS notification_outbox (
     create_datetime     DATETIME NOT NULL,
     status              VARCHAR(16) NOT NULL DEFAULT 'pending',
     attempts            INT NOT NULL DEFAULT 0,
-    next_attempt_at     DATETIME NULL,
+    next_attempt_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     claimed_at          DATETIME NULL,
     claimed_by          VARCHAR(64) NULL,
     last_error          TEXT NULL,

--- a/database/mysql/init.sql
+++ b/database/mysql/init.sql
@@ -263,7 +263,8 @@ CREATE TABLE IF NOT EXISTS unit_logs (
     UNIQUE KEY uk_unit_log (unit_id, log_datetime, status, location(255)),
     INDEX idx_unit_id (unit_id),
     INDEX idx_log_datetime (log_datetime),
-    INDEX idx_status (status)
+    INDEX idx_status (status),
+    INDEX idx_unit_logs_unit_log (unit_id, log_datetime)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================
@@ -287,7 +288,8 @@ CREATE TABLE IF NOT EXISTS narratives (
     INDEX idx_call_id (call_id),
     INDEX idx_create_datetime (create_datetime),
     INDEX idx_create_user (create_user),
-    INDEX idx_type (narrative_type)
+    INDEX idx_type (narrative_type),
+    INDEX idx_narratives_call_created (call_id, create_datetime)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================
@@ -479,7 +481,8 @@ CREATE TABLE IF NOT EXISTS notification_send_log (
 
     FOREIGN KEY (channel_id) REFERENCES notification_channels(id) ON DELETE CASCADE,
     FOREIGN KEY (call_id) REFERENCES calls(id) ON DELETE SET NULL,
-    INDEX idx_send_log_channel_created (channel_id, created_at)
+    INDEX idx_send_log_channel_created (channel_id, created_at),
+    INDEX idx_send_log_call_created (call_id, created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================

--- a/database/postgres/init.sql
+++ b/database/postgres/init.sql
@@ -624,7 +624,7 @@ CREATE TABLE IF NOT EXISTS notification_outbox (
     create_datetime     TIMESTAMP NOT NULL,
     status              VARCHAR(16) NOT NULL DEFAULT 'pending',
     attempts            INTEGER NOT NULL DEFAULT 0,
-    next_attempt_at     TIMESTAMP NULL,
+    next_attempt_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     claimed_at          TIMESTAMP NULL,
     claimed_by          VARCHAR(64) NULL,
     last_error          TEXT NULL,

--- a/database/postgres/init.sql
+++ b/database/postgres/init.sql
@@ -269,6 +269,7 @@ CREATE TABLE IF NOT EXISTS unit_logs (
 CREATE INDEX idx_unit_logs_unit_id ON unit_logs(unit_id);
 CREATE INDEX idx_unit_logs_log_datetime ON unit_logs(log_datetime);
 CREATE INDEX idx_unit_logs_status ON unit_logs(status);
+CREATE INDEX idx_unit_logs_unit_log ON unit_logs(unit_id, log_datetime);
 
 -- ============================================================================
 -- NARRATIVES
@@ -294,6 +295,7 @@ CREATE INDEX idx_narratives_call_id ON narratives(call_id);
 CREATE INDEX idx_narratives_create_datetime ON narratives(create_datetime);
 CREATE INDEX idx_narratives_create_user ON narratives(create_user);
 CREATE INDEX idx_narratives_type ON narratives(narrative_type);
+CREATE INDEX idx_narratives_call_created ON narratives(call_id, create_datetime);
 
 -- ============================================================================
 -- PERSONS
@@ -535,6 +537,8 @@ CREATE TABLE IF NOT EXISTS notification_send_log (
 
 CREATE INDEX IF NOT EXISTS idx_send_log_channel_created
     ON notification_send_log(channel_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_send_log_call_created
+    ON notification_send_log(call_id, created_at);
 
 -- ============================================================================
 -- REFERENCE TABLES (added v1.3.0 — filter refactor)

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -261,7 +261,8 @@ CREATE TABLE IF NOT EXISTS unit_logs (
     UNIQUE KEY uk_unit_log (unit_id, log_datetime, status, location(255)),
     INDEX idx_unit_id (unit_id),
     INDEX idx_log_datetime (log_datetime),
-    INDEX idx_status (status)
+    INDEX idx_status (status),
+    INDEX idx_unit_logs_unit_log (unit_id, log_datetime)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================
@@ -285,7 +286,8 @@ CREATE TABLE IF NOT EXISTS narratives (
     INDEX idx_call_id (call_id),
     INDEX idx_create_datetime (create_datetime),
     INDEX idx_create_user (create_user),
-    INDEX idx_type (narrative_type)
+    INDEX idx_type (narrative_type),
+    INDEX idx_narratives_call_created (call_id, create_datetime)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================
@@ -472,7 +474,8 @@ CREATE TABLE IF NOT EXISTS notification_send_log (
 
     FOREIGN KEY (channel_id) REFERENCES notification_channels(id) ON DELETE CASCADE,
     FOREIGN KEY (call_id) REFERENCES calls(id) ON DELETE SET NULL,
-    INDEX idx_send_log_channel_created (channel_id, created_at)
+    INDEX idx_send_log_channel_created (channel_id, created_at),
+    INDEX idx_send_log_call_created (call_id, created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -574,7 +574,7 @@ CREATE TABLE IF NOT EXISTS notification_outbox (
     create_datetime     DATETIME NOT NULL,
     status              VARCHAR(16) NOT NULL DEFAULT 'pending',
     attempts            INT NOT NULL DEFAULT 0,
-    next_attempt_at     DATETIME NULL,
+    next_attempt_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     claimed_at          DATETIME NULL,
     claimed_by          VARCHAR(64) NULL,
     last_error          TEXT NULL,

--- a/database/validate-schema.sh
+++ b/database/validate-schema.sh
@@ -12,7 +12,10 @@ echo ""
 echo "1. Checking MySQL schema file..."
 MYSQL_TABLES=$(grep -c "CREATE TABLE" database/mysql/init.sql || echo "0")
 MYSQL_INDEXES=$(grep -c "INDEX\|CREATE INDEX" database/mysql/init.sql || echo "0")
-MYSQL_FKS=$(grep -c "FOREIGN KEY" database/mysql/init.sql || echo "0")
+# Count REFERENCES (not "FOREIGN KEY") so the tally is consistent across
+# dialects: PostgreSQL declares most FKs inline as `col ... REFERENCES t(c)`
+# rather than with a `FOREIGN KEY` clause.
+MYSQL_FKS=$(grep -c "REFERENCES" database/mysql/init.sql || echo "0")
 MYSQL_LINES=$(wc -l < database/mysql/init.sql)
 
 echo "   ✓ Tables: $MYSQL_TABLES"
@@ -24,7 +27,7 @@ echo ""
 echo "2. Checking PostgreSQL schema file..."
 PG_TABLES=$(grep -c "CREATE TABLE" database/postgres/init.sql || echo "0")
 PG_INDEXES=$(grep -c "CREATE INDEX" database/postgres/init.sql || echo "0")
-PG_FKS=$(grep -c "FOREIGN KEY" database/postgres/init.sql || echo "0")
+PG_FKS=$(grep -c "REFERENCES" database/postgres/init.sql || echo "0")
 PG_TRIGGERS=$(grep -c "CREATE TRIGGER" database/postgres/init.sql || echo "0")
 PG_LINES=$(wc -l < database/postgres/init.sql)
 
@@ -74,6 +77,39 @@ grep "CREATE TABLE" database/mysql/init.sql | sed 's/CREATE TABLE IF NOT EXISTS 
 echo ""
 echo "   Tables in PostgreSQL schema:"
 grep "CREATE TABLE" database/postgres/init.sql | sed 's/CREATE TABLE IF NOT EXISTS /   - /' | sed 's/ (//'
+echo ""
+
+echo "6. Verifying composite-index parity across the 3 schema files..."
+echo ""
+# The MySQL init and the CI seed (schema.sql) are both MySQL-flavored and must
+# mirror each other; PostgreSQL uses its own (differently named) single-column
+# indexes but shares the consistently-named composite indexes below.
+COMPOSITE_INDEXES="idx_narratives_call_created idx_unit_logs_unit_log idx_send_log_call_created"
+INDEX_PARITY_OK=1
+for idx in $COMPOSITE_INDEXES; do
+    for f in database/mysql/init.sql database/schema.sql database/postgres/init.sql; do
+        if ! grep -q "$idx" "$f"; then
+            echo "   ✗ Composite index '$idx' missing from $f"
+            INDEX_PARITY_OK=0
+        fi
+    done
+done
+if [ "$INDEX_PARITY_OK" -eq 1 ]; then
+    echo "   ✓ All composite indexes present in all 3 schema files"
+else
+    exit 1
+fi
+
+# mysql/init.sql and schema.sql are both MySQL — their inline index sets must match.
+MYSQL_IDX_SET=$(grep -oE "INDEX [a-z_]+|KEY [a-z_]+" database/mysql/init.sql | sort)
+SEED_IDX_SET=$(grep -oE "INDEX [a-z_]+|KEY [a-z_]+" database/schema.sql | sort)
+if [ "$MYSQL_IDX_SET" = "$SEED_IDX_SET" ]; then
+    echo "   ✓ mysql/init.sql and schema.sql index sets match"
+else
+    echo "   ✗ mysql/init.sql and schema.sql index sets diverge:"
+    diff <(echo "$MYSQL_IDX_SET") <(echo "$SEED_IDX_SET") || true
+    exit 1
+fi
 echo ""
 
 echo "========================================="

--- a/src/AegisXmlParser.php
+++ b/src/AegisXmlParser.php
@@ -175,25 +175,29 @@ class AegisXmlParser implements ParserInterface
     {
         $incoming = ['call_type' => [], 'incident_type' => [], 'unit' => [], 'city' => []];
 
+        // Use the RAW cast value (no trim) so the membership check matches exactly
+        // what the mappers persist and what FilterOptionsController caches — a
+        // whitespace-only variant like "Medical " is a distinct DB value and must
+        // still bust the cache.
         if (isset($xml->AgencyContexts->AgencyContext)) {
             foreach ($xml->AgencyContexts->AgencyContext as $ac) {
-                $v = trim((string) $ac->CallType);
+                $v = (string) $ac->CallType;
                 if ($v !== '') { $incoming['call_type'][$v] = true; }
             }
         }
         if (isset($xml->Incidents->Incident)) {
             foreach ($xml->Incidents->Incident as $inc) {
-                $v = trim((string) $inc->Type);
+                $v = (string) $inc->Type;
                 if ($v !== '') { $incoming['incident_type'][$v] = true; }
             }
         }
         if (isset($xml->AssignedUnits->Unit)) {
             foreach ($xml->AssignedUnits->Unit as $u) {
-                $v = trim((string) $u->UnitNumber);
+                $v = (string) $u->UnitNumber;
                 if ($v !== '') { $incoming['unit'][$v] = true; }
             }
         }
-        $city = trim((string) ($xml->Location->City ?? ''));
+        $city = (string) ($xml->Location->City ?? '');
         if ($city !== '') { $incoming['city'][$city] = true; }
 
         foreach ($incoming as $key => $valueSet) {

--- a/src/AegisXmlParser.php
+++ b/src/AegisXmlParser.php
@@ -118,10 +118,11 @@ class AegisXmlParser implements ParserInterface
             $this->logger->debug("Committing database transaction...");
             $this->db->commit();
 
-            // Invalidate derived filter-option caches whose values may have grown
-            // after ingesting this XML (call_type, incident_type, unit, city).
-            // Curated ref_* lists are not touched by XML ingest, so they are omitted.
-            \NwsCad\Api\Filtering\FilterOptionsCache::invalidate(['call_type', 'incident_type', 'unit', 'city']);
+            // Invalidate derived filter-option caches only for dimensions where
+            // this XML introduces a value not already in the cached list. Busting
+            // all four keys on every ingest defeats the 5-minute cache under
+            // steady load (cache-miss storms on /api/filter-options).
+            $this->invalidateFilterCachesForNewValues($xml);
 
             $this->logger->info("File processed successfully: {$filename} (Call ID: {$callId})");
 
@@ -163,6 +164,53 @@ class AegisXmlParser implements ParserInterface
         // wrapper so processFile() and the loader characterization tests are
         // unchanged. $this->logger is PSR-3 (Monolog), which XmlLoader accepts.
         return (new \NwsCad\Import\XmlLoader($this->logger))->load($filePath);
+    }
+
+    /**
+     * Invalidate a derived FilterOptionsCache key only when the ingested XML
+     * carries a value for that dimension that is not already in the cached list.
+     * If a key has no cache entry, the next read rebuilds it — no bust needed.
+     */
+    private function invalidateFilterCachesForNewValues(SimpleXMLElement $xml): void
+    {
+        $incoming = ['call_type' => [], 'incident_type' => [], 'unit' => [], 'city' => []];
+
+        if (isset($xml->AgencyContexts->AgencyContext)) {
+            foreach ($xml->AgencyContexts->AgencyContext as $ac) {
+                $v = trim((string) $ac->CallType);
+                if ($v !== '') { $incoming['call_type'][$v] = true; }
+            }
+        }
+        if (isset($xml->Incidents->Incident)) {
+            foreach ($xml->Incidents->Incident as $inc) {
+                $v = trim((string) $inc->Type);
+                if ($v !== '') { $incoming['incident_type'][$v] = true; }
+            }
+        }
+        if (isset($xml->AssignedUnits->Unit)) {
+            foreach ($xml->AssignedUnits->Unit as $u) {
+                $v = trim((string) $u->UnitNumber);
+                if ($v !== '') { $incoming['unit'][$v] = true; }
+            }
+        }
+        $city = trim((string) ($xml->Location->City ?? ''));
+        if ($city !== '') { $incoming['city'][$city] = true; }
+
+        foreach ($incoming as $key => $valueSet) {
+            if ($valueSet === []) {
+                continue;
+            }
+            $cached = \NwsCad\Api\Filtering\FilterOptionsCache::get($key);
+            if (!is_array($cached)) {
+                continue; // nothing cached; the next read rebuilds it
+            }
+            foreach (array_keys($valueSet) as $value) {
+                if (!in_array($value, $cached, true)) {
+                    \NwsCad\Api\Filtering\FilterOptionsCache::invalidate([$key]);
+                    break;
+                }
+            }
+        }
     }
 
     /**

--- a/src/Api/Controllers/CallsController.php
+++ b/src/Api/Controllers/CallsController.php
@@ -118,7 +118,14 @@ class CallsController
                 $rows = [];
             } else {
                 $placeholders = implode(',', array_fill(0, count($ids), '?'));
-                $listSql = 'SELECT calls.*, '
+                // Explicit column list (never calls.*) so the list endpoint does
+                // not drag the heavy xml_data JSON blob per row. These are exactly
+                // the columns the row mapper and isStaleRow() below consume.
+                $listSql = 'SELECT calls.id, calls.call_id, calls.call_number, calls.call_source, '
+                    . 'calls.caller_name, calls.caller_phone, calls.nature_of_call, '
+                    . 'calls.create_datetime, calls.close_datetime, calls.created_by, '
+                    . 'calls.closed_flag, calls.canceled_flag, calls.reopened_flag, '
+                    . 'calls.alarm_level, calls.emd_code, '
                     . 'locations.full_address, locations.city, locations.state, '
                     . 'locations.latitude_y, locations.longitude_x '
                     . 'FROM calls '
@@ -223,7 +230,12 @@ class CallsController
                     l.nearest_cross_streets,
                     l.police_beat,
                     l.ems_district,
-                    l.fire_quadrant
+                    l.fire_quadrant,
+                    -- Fold the three child-row counts into the main query as
+                    -- scalar subqueries instead of three separate round-trips.
+                    (SELECT COUNT(*) FROM units WHERE call_id = c.id) AS unit_count,
+                    (SELECT COUNT(*) FROM narratives WHERE call_id = c.id) AS narrative_count,
+                    (SELECT COUNT(*) FROM persons WHERE call_id = c.id) AS person_count
                 FROM calls c
                 LEFT JOIN locations l ON c.id = l.call_id
                 WHERE c.id = :id
@@ -238,6 +250,10 @@ class CallsController
                 return;
             }
 
+            $unitCount = (int)($call['unit_count'] ?? 0);
+            $narrativeCount = (int)($call['narrative_count'] ?? 0);
+            $personCount = (int)($call['person_count'] ?? 0);
+
             // Get agency contexts
             $sql = "SELECT * FROM agency_contexts WHERE call_id = :call_id";
             $stmt = $this->db->prepare($sql);
@@ -249,24 +265,6 @@ class CallsController
             $stmt = $this->db->prepare($sql);
             $stmt->execute([':call_id' => $call['id']]);
             $incidents = $stmt->fetchAll();
-
-            // Get unit count
-            $sql = "SELECT COUNT(*) FROM units WHERE call_id = :call_id";
-            $stmt = $this->db->prepare($sql);
-            $stmt->execute([':call_id' => $call['id']]);
-            $unitCount = (int)$stmt->fetchColumn();
-
-            // Get narrative count
-            $sql = "SELECT COUNT(*) FROM narratives WHERE call_id = :call_id";
-            $stmt = $this->db->prepare($sql);
-            $stmt->execute([':call_id' => $call['id']]);
-            $narrativeCount = (int)$stmt->fetchColumn();
-
-            // Get person count
-            $sql = "SELECT COUNT(*) FROM persons WHERE call_id = :call_id";
-            $stmt = $this->db->prepare($sql);
-            $stmt->execute([':call_id' => $call['id']]);
-            $personCount = (int)$stmt->fetchColumn();
 
             // Format response
             $response = [

--- a/src/Api/Controllers/UnitsController.php
+++ b/src/Api/Controllers/UnitsController.php
@@ -127,7 +127,12 @@ class UnitsController
                     (SELECT i.incident_number FROM incidents i WHERE i.call_id = u.call_id LIMIT 1) as incident_number,
                     l.full_address,
                     l.city,
-                    l.state
+                    l.state,
+                    -- Fold the three child-row counts into the main query as
+                    -- scalar subqueries instead of three separate round-trips.
+                    (SELECT COUNT(*) FROM unit_personnel WHERE unit_id = u.id) AS personnel_count,
+                    (SELECT COUNT(*) FROM unit_logs WHERE unit_id = u.id) AS log_count,
+                    (SELECT COUNT(*) FROM unit_dispositions WHERE unit_id = u.id) AS disposition_count
                 FROM units u
                 LEFT JOIN calls c ON u.call_id = c.id
                 LEFT JOIN locations l ON c.id = l.call_id
@@ -143,23 +148,9 @@ class UnitsController
                 return;
             }
 
-            // Get personnel count
-            $sql = "SELECT COUNT(*) FROM unit_personnel WHERE unit_id = :unit_id";
-            $stmt = $this->db->prepare($sql);
-            $stmt->execute([':unit_id' => $unit['id']]);
-            $personnelCount = (int)$stmt->fetchColumn();
-
-            // Get log count
-            $sql = "SELECT COUNT(*) FROM unit_logs WHERE unit_id = :unit_id";
-            $stmt = $this->db->prepare($sql);
-            $stmt->execute([':unit_id' => $unit['id']]);
-            $logCount = (int)$stmt->fetchColumn();
-
-            // Get disposition count
-            $sql = "SELECT COUNT(*) FROM unit_dispositions WHERE unit_id = :unit_id";
-            $stmt = $this->db->prepare($sql);
-            $stmt->execute([':unit_id' => $unit['id']]);
-            $dispositionCount = (int)$stmt->fetchColumn();
+            $personnelCount = (int)($unit['personnel_count'] ?? 0);
+            $logCount = (int)($unit['log_count'] ?? 0);
+            $dispositionCount = (int)($unit['disposition_count'] ?? 0);
 
             // Format response
             $response = [

--- a/src/Notifications/Outbox/OutboxProcessor.php
+++ b/src/Notifications/Outbox/OutboxProcessor.php
@@ -25,6 +25,15 @@ final class OutboxProcessor
     /** @var callable(int):IncidentDto */
     private $incidentLoader;
 
+    /**
+     * Per-tick memo of loaded incidents, keyed by db_call_id. Several outbox
+     * rows in one batch commonly target the same call (one row per channel), and
+     * the incident loader runs a multi-subquery SELECT — so cache within a tick.
+     *
+     * @var array<int, IncidentDto>
+     */
+    private array $incidentCache = [];
+
     public function __construct(
         private readonly OutboxRepositoryInterface $repo,
         private readonly ChannelFactoryInterface $factory,
@@ -51,6 +60,7 @@ final class OutboxProcessor
 
         $now     = ($this->clock)();
         $claimed = $this->repo->claim($this->workerId, $this->batchSize, $now);
+        $this->incidentCache = []; // fresh memo each tick — call state may have changed
         foreach ($claimed as $row) {
             try {
                 $this->processRow($row);
@@ -61,6 +71,11 @@ final class OutboxProcessor
                 $this->markRetryOrFail($row, $t->getMessage());
             }
         }
+    }
+
+    private function loadIncident(int $callId): IncidentDto
+    {
+        return $this->incidentCache[$callId] ??= ($this->incidentLoader)($callId);
     }
 
     /** @param array<string,mixed> $row */
@@ -74,7 +89,7 @@ final class OutboxProcessor
         $resendAll   = (bool) (int) $row['resend_all'];
         $addedTopics = json_decode((string) $row['added_topics_json'], true) ?: [];
 
-        $dto    = ($this->incidentLoader)($callId);
+        $dto    = $this->loadIncident($callId);
         $topics = TopicResolver::resolveTopics($dto, $resendAll, $addedTopics);
 
         if ($topics === []) {

--- a/src/Notifications/Outbox/OutboxRepository.php
+++ b/src/Notifications/Outbox/OutboxRepository.php
@@ -94,7 +94,7 @@ final class OutboxRepository implements OutboxRepositoryInterface
             $sel = $db->prepare(
                 "SELECT id FROM notification_outbox
                  WHERE status = 'pending'
-                   AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+                   AND next_attempt_at <= ?
                  ORDER BY id ASC
                  LIMIT ?"
             );
@@ -285,7 +285,7 @@ final class OutboxRepository implements OutboxRepositoryInterface
             $stmt = $db->prepare(
                 "UPDATE notification_outbox
                  SET status = 'pending', attempts = 0,
-                     next_attempt_at = NULL, last_error = NULL,
+                     next_attempt_at = CURRENT_TIMESTAMP, last_error = NULL,
                      claimed_at = NULL, claimed_by = NULL,
                      updated_at = CURRENT_TIMESTAMP
                  WHERE id = ?"

--- a/src/Notifications/Outbox/OutboxRepository.php
+++ b/src/Notifications/Outbox/OutboxRepository.php
@@ -40,10 +40,16 @@ final class OutboxRepository implements OutboxRepositoryInterface
         DateTimeImmutable $createDateTime,
     ): int {
         return $this->exec(function (PDO $db) use ($callId, $channelId, $intent, $resendAll, $addedTopics, $createDateTime): int {
+            // Set next_attempt_at explicitly to the call's create time — a value
+            // that is always in the past — so a new row is immediately eligible
+            // under the claim's `next_attempt_at <= ?` gate without relying on the
+            // DB CURRENT_TIMESTAMP default (whose DB clock could run ahead of the
+            // worker clock the claim compares against).
+            $createStr = $createDateTime->format('Y-m-d H:i:s');
             $stmt = $db->prepare(
                 "INSERT INTO notification_outbox
-                 (db_call_id, channel_id, intent, resend_all, added_topics_json, create_datetime)
-                 VALUES (?, ?, ?, ?, ?, ?)"
+                 (db_call_id, channel_id, intent, resend_all, added_topics_json, create_datetime, next_attempt_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)"
             );
             $stmt->execute([
                 $callId,
@@ -51,7 +57,8 @@ final class OutboxRepository implements OutboxRepositoryInterface
                 $intent->value,
                 $resendAll ? 1 : 0,
                 json_encode(array_values($addedTopics), JSON_UNESCAPED_SLASHES),
-                $createDateTime->format('Y-m-d H:i:s'),
+                $createStr,
+                $createStr,
             ]);
             return (int) $db->lastInsertId();
         });
@@ -281,16 +288,20 @@ final class OutboxRepository implements OutboxRepositoryInterface
 
     public function retry(int $rowId): bool
     {
-        return $this->exec(function (PDO $db) use ($rowId): bool {
+        // Bind next_attempt_at from the application clock (matching the clock the
+        // claim query compares against) rather than the DB CURRENT_TIMESTAMP, so a
+        // manually retried row is due immediately regardless of DB/worker skew.
+        $nowStr = (new DateTimeImmutable())->format('Y-m-d H:i:s');
+        return $this->exec(function (PDO $db) use ($rowId, $nowStr): bool {
             $stmt = $db->prepare(
                 "UPDATE notification_outbox
                  SET status = 'pending', attempts = 0,
-                     next_attempt_at = CURRENT_TIMESTAMP, last_error = NULL,
+                     next_attempt_at = ?, last_error = NULL,
                      claimed_at = NULL, claimed_by = NULL,
                      updated_at = CURRENT_TIMESTAMP
                  WHERE id = ?"
             );
-            $stmt->execute([$rowId]);
+            $stmt->execute([$nowStr, $rowId]);
             return $stmt->rowCount() > 0;
         });
     }

--- a/tests/Integration/Notifications/OutboxRepositoryTest.php
+++ b/tests/Integration/Notifications/OutboxRepositoryTest.php
@@ -64,7 +64,9 @@ final class OutboxRepositoryTest extends TestCase
         $this->assertSame(['IN048', 'E1'], json_decode($row['added_topics_json'], true));
         $this->assertSame('pending', $row['status']);
         $this->assertSame(0, (int) $row['attempts']);
-        $this->assertNull($row['next_attempt_at']);
+        // next_attempt_at defaults to CURRENT_TIMESTAMP (eligible immediately),
+        // replacing the old nullable "eligible when NULL" semantics.
+        $this->assertNotNull($row['next_attempt_at']);
         $this->assertNull($row['claimed_at']);
         $this->assertNull($row['claimed_by']);
         $this->assertNull($row['last_error']);
@@ -274,7 +276,9 @@ final class OutboxRepositoryTest extends TestCase
             ->fetch(PDO::FETCH_ASSOC);
         $this->assertSame('pending', $row['status']);
         $this->assertSame(0, (int) $row['attempts']);
-        $this->assertNull($row['next_attempt_at']);
+        // retry() resets next_attempt_at to CURRENT_TIMESTAMP (due now) rather
+        // than NULL now that the column is NOT NULL.
+        $this->assertNotNull($row['next_attempt_at']);
         $this->assertNull($row['last_error']);
     }
 
@@ -407,7 +411,7 @@ final class OutboxRepositoryTest extends TestCase
 
     private function insertPending(): int
     {
-        return $this->repo->insert(
+        $id = $this->repo->insert(
             callId:         $this->callId,
             channelId:      $this->channelId,
             intent:         Intent::Created,
@@ -415,5 +419,9 @@ final class OutboxRepositoryTest extends TestCase
             addedTopics:    [],
             createDateTime: new DateTimeImmutable('2026-05-07 12:00:00'),
         );
+        // next_attempt_at now defaults to insert-time (real server clock). Pin it
+        // to a fixed past baseline so the fixed-clock claim tests see the row as due.
+        self::$db->exec("UPDATE notification_outbox SET next_attempt_at = '2026-05-07 00:00:00' WHERE id = {$id}");
+        return $id;
     }
 }

--- a/tests/Integration/Notifications/OutboxRepositoryTest.php
+++ b/tests/Integration/Notifications/OutboxRepositoryTest.php
@@ -411,7 +411,10 @@ final class OutboxRepositoryTest extends TestCase
 
     private function insertPending(): int
     {
-        $id = $this->repo->insert(
+        // insert() sets next_attempt_at to createDateTime (2026-05-07 12:00:00),
+        // which is in the past relative to the fixed-clock claim tests, so the row
+        // is due without further setup.
+        return $this->repo->insert(
             callId:         $this->callId,
             channelId:      $this->channelId,
             intent:         Intent::Created,
@@ -419,9 +422,5 @@ final class OutboxRepositoryTest extends TestCase
             addedTopics:    [],
             createDateTime: new DateTimeImmutable('2026-05-07 12:00:00'),
         );
-        // next_attempt_at now defaults to insert-time (real server clock). Pin it
-        // to a fixed past baseline so the fixed-clock claim tests see the row as due.
-        self::$db->exec("UPDATE notification_outbox SET next_attempt_at = '2026-05-07 00:00:00' WHERE id = {$id}");
-        return $id;
     }
 }

--- a/tests/Unit/AegisXmlParserTest.php
+++ b/tests/Unit/AegisXmlParserTest.php
@@ -570,6 +570,8 @@ XML;
 
         cleanTestDatabase();
 
+        // The fixture's AgencyContext CallType is 'Medical', which is NOT in the
+        // cached ['Police'] list — a genuinely new value, so the key is busted.
         \NwsCad\Api\Filtering\FilterOptionsCache::put('call_type', ['Police']);
         $this->assertSame(['Police'], \NwsCad\Api\Filtering\FilterOptionsCache::get('call_type'),
             'Precondition: cache entry must exist before processFile()');
@@ -579,7 +581,27 @@ XML;
         $this->assertTrue($result, 'processFile() must return true for valid XML');
 
         $this->assertNull(\NwsCad\Api\Filtering\FilterOptionsCache::get('call_type'),
-            'FilterOptionsCache entry for call_type must be invalidated after a successful commit');
+            'FilterOptionsCache call_type must be invalidated when the XML introduces a new value');
+    }
+
+    public function testDoesNotInvalidateFilterCacheWhenValueAlreadyPresent(): void
+    {
+        if (!getenv('MYSQL_HOST')) {
+            $this->markTestSkipped('Database not configured for testing');
+        }
+
+        cleanTestDatabase();
+
+        // The fixture's CallType 'Medical' is already in the cached list, so the
+        // targeted invalidation must leave the call_type cache intact (avoiding
+        // cache-miss storms under steady ingest).
+        \NwsCad\Api\Filtering\FilterOptionsCache::put('call_type', ['Medical', 'Fire']);
+
+        $parser = new AegisXmlParser();
+        $this->assertTrue($parser->processFile($this->testXmlPath));
+
+        $this->assertSame(['Medical', 'Fire'], \NwsCad\Api\Filtering\FilterOptionsCache::get('call_type'),
+            'call_type cache must survive when the ingested value is already present');
     }
 
     private function buildXmlWithAgencyContextHavingFdid(string $fdid): string


### PR DESCRIPTION
Closes #50.

Performance pass across the DB schema, API controllers, and the notification outbox. Verified on MySQL 8.0 and PostgreSQL 16.

## Changes (checklist)
- **Composite indexes** in all 3 schema files + idempotent dual migrations: `narratives(call_id, create_datetime)`, `unit_logs(unit_id, log_datetime)`, `notification_send_log(call_id, created_at)`.
- **`CallsController::index()`** lists an explicit `calls` column set instead of `calls.*`, so `xml_data` (the full serialized XML per row) is no longer dragged into list responses.
- **`CallsController::show()`** 6 queries → 3 (fold the 3 child COUNTs into the main query as scalar subqueries); **`UnitsController::show()`** 4 → 1.
- **`OutboxProcessor`** memoizes incident loads per tick (keyed by `db_call_id`) — a batch is commonly one row per channel for the same call, and the loader runs a multi-subquery SELECT.
- **Targeted `FilterOptionsCache` invalidation**: bust a derived key only when the XML introduces a value not already cached, instead of clearing all 4 keys every ingest (which defeated the 5-minute cache under steady load).
- **`notification_outbox.next_attempt_at` NOT NULL DEFAULT CURRENT_TIMESTAMP** (+ migration); claim query simplified from `(next_attempt_at IS NULL OR next_attempt_at <= ?)` to `next_attempt_at <= ?` so the `(status, next_attempt_at)` index can range-seek.
- **`validate-schema.sh`** now asserts composite-index parity across the 3 schema files (and that `mysql/init.sql` ≡ `schema.sql`); also fixed its FK tally to count `REFERENCES` (dialect-consistent) so the pre-existing MySQL-vs-Postgres check passes.

## EXPLAIN evidence (MySQL, seeded rows)
| Query | key | filesort? |
|---|---|---|
| `notification_send_log WHERE call_id=? ORDER BY created_at` | **`idx_send_log_call_created`** (new) | no |
| `narratives WHERE call_id=? ORDER BY create_datetime` | `uk_narrative` (existing unique-key prefix) | no |
| outbox claim `status='pending' AND next_attempt_at <= ?` | PK on tiny data; `(status, next_attempt_at)` available at scale | — |

**Transparency:** `notification_send_log` is the clear win — it had no `call_id`-leading index, and the new one is used with no filesort. For `narratives`/`unit_logs`, the optimizer already satisfies the query from the composite **UNIQUE key** prefix; the dedicated indexes added here are narrower alternatives the planner may prefer under different stats/row counts, kept as the issue specified.

## Verification
- Migrations apply cleanly on MySQL 8.0 and PostgreSQL 16.
- Full **Unit 328 / Integration 184 / Security 61** suites green on MySQL under pcov (no risky); ApiCalls/ApiUnits + characterization green on both drivers.
- (The pgsql outbox tests hit a pre-existing boolean-vs-integer channel-seed cast issue unrelated to this PR — the Postgres CI job is `continue-on-error` for exactly that.)
