### PR TITLE
fix(deploy): relocate DB datadir on upgrade + keep test-setup out of prod compose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ After `gh pr create`, wait for qodo (typically ≤ 2 minutes), then run the qodo
 - **Tests that call a controller** must call `Response::resetForTesting()` in `setUp()` because `Response::json()` no-ops on the second call within a request in testing mode.
 - **`cleanTestDatabase()` uses `DELETE FROM` + `ALTER TABLE ... AUTO_INCREMENT = 1`** — not `TRUNCATE`. Some MySQL versions reject `TRUNCATE` on a parent table referenced by a FK even with `FOREIGN_KEY_CHECKS=0`. Resetting auto-increment is required because several integration tests hard-code primary-key values.
 - **Test DB user** — CI uses `test_user` / `test_pass`; local docker uses `nws_user` / the compose-supplied password. The PHPUnit `<env>` tags in `phpunit.xml` only apply when the env var isn't already set, so the docker container's pre-baked env wins inside it.
+- **Local test DB (`nws_cad_test`) needs the compose test override** — the base `docker-compose.yml` deliberately omits the `test-setup.sql` seed so a production `up -d` never provisions a test DB or `test_user` on the live MySQL. For local testing, bring the stack up with `docker compose -f docker-compose.yml -f docker-compose.test.yml --profile mysql up -d`, or seed an existing volume once via `docker compose exec mysql sh -c 'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" < /docker-entrypoint-initdb.d/zz-test-setup.sql'`. CI (`tests.yml`) provisions its own MySQL service and is unaffected.
 
 ## Key environment variables
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,21 @@
+# Local test override — DO NOT use in production.
+#
+# Adds the nws_cad_test database + test_user/test_pass to the mysql service so
+# `composer test` works locally the same way it does in CI (.github/workflows/
+# tests.yml provisions the equivalent as a GitHub Actions service). This
+# scaffolding is deliberately kept OUT of the base docker-compose.yml so a
+# production `docker compose up -d` never creates a test DB or a well-known
+# test_user on the live MySQL.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.test.yml --profile mysql up -d
+#
+# The mounted SQL (zz-test-setup.sql) only runs on a FRESH data volume, because
+# the mysql entrypoint runs docker-entrypoint-initdb.d scripts once. To seed an
+# existing volume, apply it manually:
+#   docker compose exec mysql sh -c \
+#     'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" < /docker-entrypoint-initdb.d/zz-test-setup.sql'
+services:
+  mysql:
+    volumes:
+      - ./database/mysql/test-setup.sql:/docker-entrypoint-initdb.d/zz-test-setup.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,10 @@ services:
     volumes:
       - ${NWS_VAR_DIR:-./var}/data/mysql:/var/lib/mysql
       - ./database/mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
-      - ./database/mysql/test-setup.sql:/docker-entrypoint-initdb.d/zz-test-setup.sql
+      # The nws_cad_test DB + test_user are NOT seeded here — that scaffolding
+      # must never land on a production MySQL. For local testing, opt in with the
+      # override: docker compose -f docker-compose.yml -f docker-compose.test.yml \
+      #   --profile mysql up -d   (see docker-compose.test.yml / docs/TESTING.md).
       - ./docker/mysql/my.cnf:/etc/mysql/conf.d/custom.cnf:ro
     ports:
       - "${MYSQL_PORT:-3306}:3306"

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -99,8 +99,14 @@ mysql -u root -p -e "CREATE DATABASE nws_cad_test;"
 mysql -u root -p -e "GRANT ALL ON nws_cad_test.* TO 'test_user'@'localhost' IDENTIFIED BY 'test_pass';"
 mysql -u test_user -ptest_pass nws_cad_test < database/mysql/init.sql
 
-# Docker
-docker-compose exec mysql mysql -u root -proot_password -e "CREATE DATABASE nws_cad_test;"
+# Docker — bring the stack up WITH the test override so the mysql:8.0 entrypoint
+# auto-creates nws_cad_test + test_user on a fresh data volume. The base
+# docker-compose.yml deliberately omits this seed so a production `up -d` never
+# provisions a test DB / test_user on the live database.
+docker compose -f docker-compose.yml -f docker-compose.test.yml --profile mysql up -d
+
+# Existing (already-initialized) volume — the initdb seed won't re-run; apply it once:
+docker compose exec mysql sh -c 'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" < /docker-entrypoint-initdb.d/zz-test-setup.sql'
 ```
 
 ### Configuration

--- a/docs/deployment/RUNBOOK.md
+++ b/docs/deployment/RUNBOOK.md
@@ -84,17 +84,26 @@ Bring the DB up first (without the app), then apply:
 > ```bash
 > docker compose --profile "$DB_TYPE" down          # datadir can't move while the DB holds it
 > TS=$(date +%Y%m%d-%H%M%S)
-> docker run --rm -e TS="$TS" -e SVC="$DB_SVC" -v "$PWD:/proj" alpine sh -c '
->   srcsz=$(du -sm "/proj/data/$SVC" 2>/dev/null | cut -f1)
->   if [ -z "$srcsz" ]; then echo "no ./data/$SVC — nothing to relocate"; exit 0; fi
->   dstsz=$(du -sm "/proj/var/data/$SVC" 2>/dev/null | cut -f1); dstsz=${dstsz:-0}
->   if [ "$dstsz" -ge "$srcsz" ]; then echo "ABORT: ./var/data/$SVC (${dstsz}MB) >= ./data/$SVC (${srcsz}MB) — inspect manually"; exit 1; fi
->   if [ -e "/proj/var/data/$SVC" ]; then mv "/proj/var/data/$SVC" "/proj/var/data/$SVC.freshinit-$TS"; fi
->   mkdir -p /proj/var/data
->   mv "/proj/data/$SVC" "/proj/var/data/$SVC"
->   echo "relocated ./data/$SVC -> ./var/data/$SVC ($(du -sm /proj/var/data/$SVC | cut -f1)MB)"
+> DEST_BASE="${NWS_VAR_DIR:-./var}"                  # resolve the SAME base docker-compose.yml mounts
+> mkdir -p "$DEST_BASE/data"
+> docker run --rm -e TS="$TS" -e SVC="$DB_SVC" \
+>   -v "$PWD:/proj" -v "$(cd "$DEST_BASE/data" && pwd):/new" alpine sh -c '
+>   if [ ! -d "/proj/data/$SVC" ]; then echo "no ./data/$SVC — nothing to relocate"; exit 0; fi
+>   srcsz=$(du -sk "/proj/data/$SVC" | cut -f1)
+>   if [ -d "/new/$SVC" ] && [ -n "$(ls -A "/new/$SVC" 2>/dev/null)" ]; then
+>     dstsz=$(du -sk "/new/$SVC" | cut -f1)
+>     if [ "$dstsz" -ge "$srcsz" ]; then echo "ABORT: destination $SVC (${dstsz}KiB) is non-empty and >= source (${srcsz}KiB) — inspect manually"; exit 1; fi
+>   fi
+>   if [ -e "/new/$SVC" ]; then mv "/new/$SVC" "/new/$SVC.freshinit-$TS"; fi
+>   mv "/proj/data/$SVC" "/new/$SVC"
+>   echo "relocated ./data/$SVC -> $DEST_BASE/data/$SVC ($(du -sk /new/$SVC | cut -f1)KiB)"
 > '
 > ```
+> Resolving `$DEST_BASE` from `NWS_VAR_DIR` (via `cd … && pwd`) keeps the destination identical to
+> the compose bind even when it's overridden to an absolute path. The size guard uses KiB and only
+> aborts when the destination is **non-empty and ≥ the source**, so a small fresh init never
+> false-aborts. On a single filesystem you can skip the container and just
+> `mv ./data/$DB_SVC "$DEST_BASE/data/$DB_SVC"` for an instant rename.
 
 - [ ] Start just the database (service name is `$DB_SVC` — `mysql` or `postgres`) and wait until it actually accepts connections:
   ```bash

--- a/docs/deployment/RUNBOOK.md
+++ b/docs/deployment/RUNBOOK.md
@@ -72,6 +72,30 @@ schema fully up to date, including `notification_channels.last_updated_actor`
 (#37) and the v2.0.2 indexes / `notification_outbox.next_attempt_at` change.
 Bring the DB up first (without the app), then apply:
 
+> **⚠ Existing deployments — relocate the database data directory first (one-time).**
+> v2.0.x stores the DB datadir at `${NWS_VAR_DIR:-./var}/data/$DB_SVC` (i.e. `./var/data/mysql`
+> or `./var/data/postgres`). Deployments created before this used `./data/$DB_SVC`. If yours
+> still has data at the old path, the DB container will start on an **empty** directory, re-run
+> `init.sql`, and come up blank — your real data is left untouched at `./data/$DB_SVC`, but the
+> app gets pointed at nothing. With the stack **stopped**, move the datadir into place. This is a
+> no-op on fresh installs and already-migrated hosts (no `./data/$DB_SVC`), and it aborts rather
+> than overwrite a destination that already holds a larger (real) datadir:
+>
+> ```bash
+> docker compose --profile "$DB_TYPE" down          # datadir can't move while the DB holds it
+> TS=$(date +%Y%m%d-%H%M%S)
+> docker run --rm -e TS="$TS" -e SVC="$DB_SVC" -v "$PWD:/proj" alpine sh -c '
+>   srcsz=$(du -sm "/proj/data/$SVC" 2>/dev/null | cut -f1)
+>   if [ -z "$srcsz" ]; then echo "no ./data/$SVC — nothing to relocate"; exit 0; fi
+>   dstsz=$(du -sm "/proj/var/data/$SVC" 2>/dev/null | cut -f1); dstsz=${dstsz:-0}
+>   if [ "$dstsz" -ge "$srcsz" ]; then echo "ABORT: ./var/data/$SVC (${dstsz}MB) >= ./data/$SVC (${srcsz}MB) — inspect manually"; exit 1; fi
+>   if [ -e "/proj/var/data/$SVC" ]; then mv "/proj/var/data/$SVC" "/proj/var/data/$SVC.freshinit-$TS"; fi
+>   mkdir -p /proj/var/data
+>   mv "/proj/data/$SVC" "/proj/var/data/$SVC"
+>   echo "relocated ./data/$SVC -> ./var/data/$SVC ($(du -sm /proj/var/data/$SVC | cut -f1)MB)"
+> '
+> ```
+
 - [ ] Start just the database (service name is `$DB_SVC` — `mysql` or `postgres`) and wait until it actually accepts connections:
   ```bash
   docker compose --profile "$DB_TYPE" up -d "$DB_SVC"


### PR DESCRIPTION
## Why

Both issues were hit live during the **v2.0.2 production upgrade** (v1.1.17 → v2.0.2). The runbook ran clean but the app briefly came up on an **empty database** — root-caused to a compose data-path change with no migration step. Recovered with zero data loss; these changes stop it recurring.

## What

### 1. Data-directory relocation step (RUNBOOK.md)
The DB data bind path changed from `./data/<svc>` → `${NWS_VAR_DIR:-./var}/data/<svc>`. On an existing deployment, `docker compose up -d` recreates the DB on the **new empty path**, re-runs `init.sql`, and comes up blank while the real data sits orphaned at `./data/<svc>`.

Added a **guarded, one-time relocation step** to Step 4:
- No-op on fresh installs / already-migrated hosts (no `./data/<svc>`).
- **Aborts** rather than overwrite a destination that already holds a larger (real) datadir.
- Works for both `mysql` and `postgres` (`$DB_SVC`).

### 2. Keep test scaffolding out of production compose
Base `docker-compose.yml` mounted `database/mysql/test-setup.sql` as an initdb script → a fresh **production** volume would create `nws_cad_test` and a well-known `test_user`/`test_pass` on the live MySQL.

- Removed that mount from the base compose.
- Added opt-in **`docker-compose.test.yml`** override for local testing.
- `docs/TESTING.md` + `CLAUDE.md` document the new `-f docker-compose.yml -f docker-compose.test.yml` invocation.
- **CI is unaffected** — `tests.yml` provisions its own MySQL service, not this compose file.

## Verification
- `docker compose -f docker-compose.yml --profile mysql config` → valid; base contains **no** `test-setup`.
- `docker compose -f docker-compose.yml -f docker-compose.test.yml --profile mysql config` → seed mount present (`zz-test-setup.sql`).
- Relocation snippet is idempotent/guarded (size-compare abort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)