### PR TITLE
fix(dashboard): accessibility, color-independent priority, and design tokens (UI audit)

### DIFF
--- a/public/assets/css/dashboard.css
+++ b/public/assets/css/dashboard.css
@@ -11,13 +11,39 @@
     --info-color: #0dcaf0;
     --dark-color: #212529;
     --light-color: #f8f9fa;
+
+    /* Brand palette (single source of truth — was duplicated as raw hex across
+       .dashboard-banner / .gradient-card-header / .analytics-modal-header and filters.css) */
+    --brand-1: #4f46e5;
+    --brand-2: #7c3aed;
+    --brand-3: #db2777;
+    --brand-gradient: linear-gradient(135deg, var(--brand-1) 0%, var(--brand-2) 50%, var(--brand-3) 100%);
+    --brand-gradient-2: linear-gradient(135deg, var(--brand-1) 0%, var(--brand-2) 100%);
+
+    /* Slate neutral used by pill badges */
+    --slate-bg: #e2e8f0;
+    --slate-fg: #475569;
+
+    /* Muted text that meets WCAG AA (4.5:1) on the off-white body — replaces #6c757d */
+    --text-muted-accessible: #5c636a;
+
+    /* Colorblind-safe categorical palette (Okabe-Ito) — consumed by charts.js via
+       getComputedStyle so chart colors and CSS never drift. */
+    --cat-1: #0072b2;
+    --cat-2: #e69f00;
+    --cat-3: #009e73;
+    --cat-4: #cc79a7;
+    --cat-5: #56b4e9;
+    --cat-6: #d55e00;
+    --cat-7: #f0e442;
+    --cat-8: #999999;
 }
 
 /* Global Styles */
 body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     background-color: #f5f7fa;
-    min-height: 100vh;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
 }
@@ -251,6 +277,14 @@ body:has(.dashboard-row-fill) > footer {
     font-size: 14px;
 }
 
+/* Priority numeral inside a marker — non-color reinforcement of priority */
+.custom-marker .marker-circle .marker-priority {
+    color: #fff;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1;
+}
+
 .custom-marker .marker-circle--red    { background-color: #dc3545; }
 .custom-marker .marker-circle--yellow { background-color: #ffc107; }
 .custom-marker .marker-circle--blue   { background-color: #0dcaf0; }
@@ -275,7 +309,7 @@ body:has(.dashboard-row-fill) > footer {
 
 .recent-call-time {
     font-size: 0.875rem;
-    color: #6c757d;
+    color: var(--text-muted-accessible);
 }
 
 .recent-call-type {
@@ -285,7 +319,7 @@ body:has(.dashboard-row-fill) > footer {
 
 .recent-call-location {
     font-size: 0.875rem;
-    color: #6c757d;
+    color: var(--text-muted-accessible);
 }
 
 /* Tables */
@@ -569,7 +603,7 @@ footer a:hover {
 .empty-state {
     text-align: center;
     padding: 3rem 1rem;
-    color: #6c757d;
+    color: var(--text-muted-accessible);
 }
 
 .empty-state i {
@@ -601,14 +635,14 @@ Timestamp: Wed Jan 28 01:35:28 UTC 2026
 
 /* === Dashboard prettify components (mirrors notifications page palette) === */
 .dashboard-banner {
-    background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 50%, #db2777 100%);
+    background: var(--brand-gradient);
     color: #fff;
     border-radius: 0.75rem;
     padding: 1.25rem 1.5rem;
     margin-bottom: 1rem;
     box-shadow: 0 4px 14px rgba(79, 70, 229, 0.25);
 }
-.dashboard-banner h2 { margin: 0; font-weight: 600; }
+.dashboard-banner h1 { margin: 0; font-weight: 600; }
 .dashboard-banner .subtitle { opacity: 0.85; font-size: 0.9rem; margin-top: 0.25rem; }
 .dashboard-banner .btn-light {
     background: rgba(255, 255, 255, 0.95);
@@ -651,8 +685,8 @@ Timestamp: Wed Jan 28 01:35:28 UTC 2026
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    background: #e2e8f0;
-    color: #475569;
+    background: var(--slate-bg);
+    color: var(--slate-fg);
 }
 .pill-badge.is-info       { background: rgba(255, 255, 255, 0.22); color: #fff; border: 1px solid rgba(255, 255, 255, 0.3); }
 .pill-badge.is-priority-1 { background: #fee2e2; color: #991b1b; }
@@ -660,11 +694,11 @@ Timestamp: Wed Jan 28 01:35:28 UTC 2026
 .pill-badge.is-priority-3 { background: #e0f2fe; color: #075985; }
 .pill-badge.is-active     { background: #d1fae5; color: #065f46; }
 .pill-badge.is-reopened   { background: #fef3c7; color: #92400e; }
-.pill-badge.is-closed     { background: #e2e8f0; color: #475569; }
+.pill-badge.is-closed     { background: var(--slate-bg); color: var(--slate-fg); }
 
 /* Gradient card header strip — applied to map + Recent Calls cards */
 .gradient-card-header {
-    background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%) !important;
+    background: var(--brand-gradient-2) !important;
     color: #fff;
     border-bottom: none !important;
     border-radius: 12px 12px 0 0 !important;
@@ -703,8 +737,8 @@ Timestamp: Wed Jan 28 01:35:28 UTC 2026
     flex-shrink: 0;
 }
 .stat-card-v2 .card-body { padding: 0.55rem 0.9rem; }
-.stat-card-v2 h2 { font-size: 1.5rem; font-weight: 700; line-height: 1.15; }
-.stat-card-v2 h6 { font-size: 0.75rem; font-weight: 500; text-transform: uppercase; letter-spacing: 0.04em; }
+.stat-card-v2 .stat-value { font-size: 1.5rem; font-weight: 700; line-height: 1.15; margin: 0; }
+.stat-card-v2 .stat-label { font-size: 0.75rem; font-weight: 500; text-transform: uppercase; letter-spacing: 0.04em; }
 .stat-card-v2 .stat-icon { width: 40px; height: 40px; font-size: 1.1rem; }
 .stat-card-v2 .summary-chips { font-size: 0.7rem; }
 
@@ -723,7 +757,7 @@ Timestamp: Wed Jan 28 01:35:28 UTC 2026
 
 /* Analytics modal — same gradient header palette as .dashboard-banner */
 .analytics-modal-header {
-    background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 50%, #db2777 100%) !important;
+    background: var(--brand-gradient) !important;
     color: #fff !important;
     border-bottom: none !important;
     padding: 1rem 1.5rem;
@@ -764,6 +798,10 @@ Timestamp: Wed Jan 28 01:35:28 UTC 2026
 #filter-drawer { z-index: 1080; }
 .offcanvas-backdrop { z-index: 1075; }
 
+/* Clickable/keyboard-activatable call rows (was an inline style="cursor:pointer" —
+   moved here so style-src CSP can stay strict). */
+tr.call-row { cursor: pointer; }
+
 /* Recent Calls row flash on insert */
 .recent-calls-card tbody tr.row-new {
     animation: row-flash 1.2s ease;
@@ -786,6 +824,86 @@ Timestamp: Wed Jan 28 01:35:28 UTC 2026
 
 /* Modal map sizing — was inline style="height: 600px; width: 100%;" */
 #modal-map { height: 600px; width: 100%; }
+
+/* === Accessibility & UI-audit utilities === */
+
+/* WCAG-AA muted text everywhere Bootstrap's .text-muted (#6c757d) was too light
+   on the off-white body. The gradient-card-header override (white) still wins by
+   specificity, so headers are unaffected. */
+.text-muted { color: var(--text-muted-accessible) !important; }
+
+/* Tabular figures so refreshing counts / timestamps don't jitter width every poll */
+.tabular-nums { font-variant-numeric: tabular-nums; }
+
+/* Skip link: hidden until focused, then pinned top-left over the navbar */
+.skip-link {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 2000;
+    padding: 0.5rem 1rem;
+    background: var(--brand-1);
+    color: #fff;
+    font-weight: 600;
+    border-radius: 0 0 6px 0;
+    transform: translateY(-120%);
+    transition: transform 0.15s ease;
+}
+.skip-link:focus {
+    transform: translateY(0);
+    outline: 3px solid #fff;
+    outline-offset: -3px;
+}
+
+/* Sortable table headers (recent-calls) */
+th.sortable {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+th.sortable:hover { background-color: rgba(13, 110, 253, 0.06); }
+th.sortable .sort-ind {
+    opacity: 0.35;
+    margin-left: 0.25rem;
+    font-size: 0.7em;
+}
+th.sortable[aria-sort="ascending"] .sort-ind,
+th.sortable[aria-sort="descending"] .sort-ind { opacity: 1; }
+/* Keyboard focus for sortable headers and interactive rows */
+th.sortable:focus-visible,
+tr.call-row:focus-visible {
+    outline: 3px solid var(--brand-1);
+    outline-offset: -3px;
+}
+
+/* Map priority legend (colour is reinforced by the numeral, so it is not
+   color-only). Swatch colours reuse the .marker-circle--* palette. */
+.map-legend {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem 0.9rem;
+    padding: 0.4rem 0.75rem;
+    font-size: 0.75rem;
+    background: #fff;
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+.map-legend .legend-label { font-weight: 600; color: var(--text-muted-accessible); }
+.map-legend .legend-item { display: inline-flex; align-items: center; gap: 0.3rem; }
+.map-legend .legend-swatch {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 2px solid #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 0.62rem;
+    font-weight: 700;
+}
+
 
 /* Floating info card overlaid on the modal map */
 .map-info-overlay {

--- a/public/assets/css/dashboard.css
+++ b/public/assets/css/dashboard.css
@@ -285,11 +285,13 @@ body:has(.dashboard-row-fill) > footer {
     line-height: 1;
 }
 
-.custom-marker .marker-circle--red    { background-color: #dc3545; }
-.custom-marker .marker-circle--yellow { background-color: #ffc107; }
-.custom-marker .marker-circle--blue   { background-color: #0dcaf0; }
-.custom-marker .marker-circle--green  { background-color: #198754; }
-.custom-marker .marker-circle--gray   { background-color: #6c757d; }
+/* Marker + legend swatch colours share the same classes. The legend uses them
+   outside .custom-marker, so both ancestors are listed here. */
+.custom-marker .marker-circle--red,    .map-legend .marker-circle--red    { background-color: #dc3545; }
+.custom-marker .marker-circle--yellow, .map-legend .marker-circle--yellow { background-color: #ffc107; }
+.custom-marker .marker-circle--blue,   .map-legend .marker-circle--blue   { background-color: #0dcaf0; }
+.custom-marker .marker-circle--green,  .map-legend .marker-circle--green  { background-color: #198754; }
+.custom-marker .marker-circle--gray,   .map-legend .marker-circle--gray   { background-color: #6c757d; }
 
 /* Recent Calls List */
 .recent-call-item {

--- a/public/assets/js/charts.js
+++ b/public/assets/js/charts.js
@@ -5,11 +5,125 @@
 
 const ChartManager = {
     charts: {},
-    defaultColors: [
-        '#0d6efd', '#198754', '#ffc107', '#dc3545', '#0dcaf0',
-        '#6610f2', '#fd7e14', '#20c997', '#6f42c1', '#d63384'
+
+    // Okabe-Ito colorblind-safe categorical palette. Used as a hardcoded fallback
+    // when the CSS `--cat-1`..`--cat-8` tokens are not present on :root. Order is
+    // arranged so no pure green sits directly next to a pure red.
+    okabeItoFallback: [
+        '#0072b2', '#e69f00', '#009e73', '#cc79a7',
+        '#56b4e9', '#d55e00', '#f0e442', '#999999'
     ],
-    
+    _categoricalColors: null,
+
+    /**
+     * Resolve the colorblind-safe categorical palette. Reads `--cat-1`..`--cat-8`
+     * from :root (Okabe-Ito, added by the integrator to dashboard.css) and falls
+     * back to the hardcoded Okabe-Ito array per-slot when a token is missing.
+     * Cached after first resolution.
+     */
+    getCategoricalColors() {
+        if (this._categoricalColors) return this._categoricalColors;
+        const styles = getComputedStyle(document.documentElement);
+        const colors = [];
+        for (let i = 1; i <= 8; i++) {
+            const token = styles.getPropertyValue(`--cat-${i}`).trim();
+            colors.push(token || this.okabeItoFallback[i - 1]);
+        }
+        this._categoricalColors = colors;
+        return colors;
+    },
+
+    /**
+     * Repeat the categorical palette to cover `count` series.
+     */
+    categoricalColors(count) {
+        const base = this.getCategoricalColors();
+        const out = [];
+        for (let i = 0; i < count; i++) {
+            out.push(base[i % base.length]);
+        }
+        return out;
+    },
+
+    /**
+     * Populate the accessible name + visually-hidden data summary for a chart canvas.
+     * Charts are `role="img"` in the markup; screen readers otherwise get nothing.
+     * We compose the canvas `aria-label` from its `data-chart-title` plus the key
+     * numbers, and fill a sibling `#<canvasId>-summary` element with a data table.
+     */
+    applyChartA11y(canvasId, data) {
+        const canvas = document.getElementById(canvasId);
+        if (!canvas) return;
+
+        const title = (canvas.dataset.chartTitle
+            || canvas.getAttribute('aria-label')
+            || 'Chart').trim();
+        const labels = (data && data.labels) || [];
+        const datasets = (data && data.datasets) || [];
+        const primary = datasets[0] || { data: [] };
+        const primaryData = primary.data || [];
+
+        // Short key-numbers sentence for the aria-label.
+        let sentence;
+        if (!labels.length) {
+            sentence = 'No data available';
+        } else {
+            sentence = labels
+                .map((label, i) => `${label}: ${primaryData[i] ?? 0}`)
+                .join(', ');
+        }
+        canvas.setAttribute('aria-label', `${title}. ${sentence}.`);
+
+        // Full data table alternative in the visually-hidden sibling element.
+        const summaryEl = document.getElementById(`${canvasId}-summary`);
+        if (!summaryEl) return;
+
+        if (!labels.length) {
+            summaryEl.textContent = `${title}: no data available.`;
+            return;
+        }
+
+        const table = document.createElement('table');
+        const caption = document.createElement('caption');
+        caption.textContent = `${title} (data table)`;
+        table.appendChild(caption);
+
+        const thead = document.createElement('thead');
+        const headRow = document.createElement('tr');
+        const catTh = document.createElement('th');
+        catTh.scope = 'col';
+        catTh.textContent = 'Category';
+        headRow.appendChild(catTh);
+        datasets.forEach((ds, i) => {
+            const th = document.createElement('th');
+            th.scope = 'col';
+            th.textContent = ds.label || `Series ${i + 1}`;
+            headRow.appendChild(th);
+        });
+        thead.appendChild(headRow);
+        table.appendChild(thead);
+
+        const tbody = document.createElement('tbody');
+        labels.forEach((label, rowIdx) => {
+            const tr = document.createElement('tr');
+            const th = document.createElement('th');
+            th.scope = 'row';
+            th.textContent = label;
+            tr.appendChild(th);
+            datasets.forEach((ds) => {
+                const td = document.createElement('td');
+                const val = (ds.data || [])[rowIdx];
+                td.textContent = val ?? 0;
+                tr.appendChild(td);
+            });
+            tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+
+        summaryEl.textContent = '';
+        summaryEl.appendChild(table);
+    },
+
     /**
      * Destroy a chart if it exists
      */
@@ -57,10 +171,12 @@ const ChartManager = {
             data: data,
             options: { ...defaultOptions, ...options }
         });
-        
+
+        this.applyChartA11y(canvasId, data);
+
         return this.charts[canvasId];
     },
-    
+
     /**
      * Create a bar chart
      */
@@ -94,10 +210,12 @@ const ChartManager = {
             data: data,
             options: { ...defaultOptions, ...options }
         });
-        
+
+        this.applyChartA11y(canvasId, data);
+
         return this.charts[canvasId];
     },
-    
+
     /**
      * Create a pie chart
      */
@@ -123,10 +241,12 @@ const ChartManager = {
             data: data,
             options: { ...defaultOptions, ...options }
         });
-        
+
+        this.applyChartA11y(canvasId, data);
+
         return this.charts[canvasId];
     },
-    
+
     /**
      * Create a doughnut chart
      */
@@ -152,18 +272,21 @@ const ChartManager = {
             data: data,
             options: { ...defaultOptions, ...options }
         });
-        
+
+        this.applyChartA11y(canvasId, data);
+
         return this.charts[canvasId];
     },
-    
+
     /**
      * Update chart data
      */
     updateChart(chartId, data) {
         if (!this.charts[chartId]) return;
-        
+
         this.charts[chartId].data = data;
         this.charts[chartId].update();
+        this.applyChartA11y(chartId, data);
     },
     
     /**
@@ -214,7 +337,7 @@ const ChartManager = {
             labels: callStats.by_type.map(item => `${item.type} (${item.count})`),
             datasets: [{
                 data: callStats.by_type.map(item => item.count),
-                backgroundColor: this.defaultColors.slice(0, callStats.by_type.length)
+                backgroundColor: this.categoricalColors(callStats.by_type.length)
             }]
         };
     },
@@ -234,20 +357,22 @@ const ChartManager = {
             };
         }
         
+        // Colorblind-safe (Okabe-Ito) status colors. No pure green/red pairing:
+        // available=bluish-green, enroute=orange, onscene=vermillion, offduty=gray.
         const statusColors = {
-            'available': '#198754',
-            'enroute': '#ffc107',
-            'onscene': '#dc3545',
-            'offduty': '#6c757d'
+            'available': '#009e73',
+            'enroute': '#e69f00',
+            'onscene': '#d55e00',
+            'offduty': '#999999'
         };
-        
+
         return {
             labels: unitStats.by_status.map(item => item.status),
             datasets: [{
                 label: 'Units',
                 data: unitStats.by_status.map(item => item.count),
-                backgroundColor: unitStats.by_status.map(item => 
-                    statusColors[item.status.toLowerCase()] || '#6c757d'
+                backgroundColor: unitStats.by_status.map(item =>
+                    statusColors[item.status.toLowerCase()] || '#999999'
                 )
             }]
         };
@@ -302,7 +427,7 @@ const ChartManager = {
             datasets: [{
                 label: 'Call Count',
                 data: agencyStats.by_agency.map(item => item.count),
-                backgroundColor: this.defaultColors.slice(0, agencyStats.by_agency.length)
+                backgroundColor: this.categoricalColors(agencyStats.by_agency.length)
             }]
         };
     },

--- a/public/assets/js/dashboard-main.js
+++ b/public/assets/js/dashboard-main.js
@@ -313,21 +313,14 @@
 
                 const url = '/calls?' + pagingParams.toString();
                 console.log('[Dashboard Main] Recent calls API URL:', url);
-                console.log('[Dashboard Main] Query params:', pagingParams.toString());
-                
-                console.log('[Dashboard Main] Fetching:', Dashboard.config.apiBaseUrl + url);
-                
-                const response = await fetch(Dashboard.config.apiBaseUrl + url);
-                const result = await response.json();
-                
-                console.log('[Dashboard Main] Calls response:', result);
-                
-                if (!result.success) {
-                    throw new Error(result.error || 'API failed');
-                }
-                
-                const calls = result.data?.items || [];
-                const pagination = result.data?.pagination || {};
+
+                // Route through the centralized wrapper for consistent error handling
+                // and security controls; it returns the unwrapped `data` and throws
+                // on failure (handled by the catch below).
+                const data = await Dashboard.apiRequest(url);
+
+                const calls = data?.items || [];
+                const pagination = data?.pagination || {};
                 currentCallsTotal = pagination.total || calls.length;
                 totalCallsPages = pagination.total_pages || 1;
                 
@@ -446,9 +439,7 @@
                         </tr>
                     `;
                 }
-                if (Dashboard.showError) {
-                    Dashboard.showError('Failed to load recent calls');
-                }
+                // Dashboard.apiRequest already surfaces the error toast — no duplicate here.
             }
         }
         
@@ -1411,7 +1402,9 @@
             root: document.getElementById('filter-panel'),
             onChange: function (state) {
                 currentQs = state.toQueryString();
-                onFilterChange();
+                // Return the refresh promise so FilterPanel keeps its busy/aria-busy
+                // state until the data actually finishes loading.
+                return onFilterChange();
             },
         });
         await panel.mount();

--- a/public/assets/js/dashboard-main.js
+++ b/public/assets/js/dashboard-main.js
@@ -65,6 +65,10 @@
         // Initialize map
         let map = null;
         const previousCallIds = new Set();
+        // Recent-calls sort state (only columns the API allows: create_datetime, call_number)
+        let currentSortKey = 'create_datetime';
+        let currentSortOrder = 'desc';
+        let lastCallsAnnouncement = '';
 
         function setDashboardLivePill(state) {
             const pill = document.getElementById('dashboard-live-pill');
@@ -290,8 +294,8 @@
                 const pagingParams = new URLSearchParams(currentQs);
                 pagingParams.set('page', page);
                 pagingParams.set('per_page', callsPerPage);
-                pagingParams.set('sort', 'create_datetime');
-                pagingParams.set('order', 'desc');
+                pagingParams.set('sort', currentSortKey);
+                pagingParams.set('order', currentSortOrder);
 
                 // Update card title based on status filter
                 const titleEl = document.getElementById('recent-calls-title');
@@ -376,7 +380,7 @@
                         }
                         
                         return `
-                            <tr class="call-row" data-call-id="${call.id}" style="cursor: pointer;">
+                            <tr class="call-row" data-call-id="${call.id}" role="button" tabindex="0" aria-label="View details for call ${Dashboard.escapeHtml(call.call_number || call.id)}">
                                 <td>${Dashboard.escapeHtml(call.call_number || call.id)}</td>
                                 <td><small>${Dashboard.formatTime(call.create_datetime)}</small></td>
                                 <td>${Dashboard.formatCallTypes(call)}</td>
@@ -425,7 +429,11 @@
                 
                 // Update pagination controls
                 updateCallsPagination(pagination);
-                
+
+                // Announce a concise summary to screen readers (deduped so the 5s poll
+                // doesn't chatter — only re-announces when the summary actually changes).
+                announceCallsStatus(calls.length);
+
             } catch (error) {
                 console.error('[Dashboard Main] Recent calls error:', error);
                 const tableBody = document.getElementById('recent-calls-body');
@@ -679,11 +687,89 @@
             
             // Remove existing listener if any
             tableBody.removeEventListener('click', handleTableClick);
-            
-            // Add new listener for all clicks
+            tableBody.removeEventListener('keydown', handleTableKeydown);
+
+            // Add new listeners for clicks and keyboard activation
             tableBody.addEventListener('click', handleTableClick);
-            
+            tableBody.addEventListener('keydown', handleTableKeydown);
+
             console.log('[Dashboard Main] Table click handlers attached');
+        }
+
+        /**
+         * Keyboard activation for the focusable call rows (Enter / Space open details).
+         * Native <button>s inside the row keep their own behavior.
+         */
+        function handleTableKeydown(event) {
+            if (event.key !== 'Enter' && event.key !== ' ' && event.key !== 'Spacebar') return;
+            if (event.target.closest('button')) return; // let inner buttons handle themselves
+            const row = event.target.closest('.call-row');
+            if (!row) return;
+            event.preventDefault();
+            viewCallDetails(parseInt(row.dataset.callId));
+        }
+
+        /**
+         * Concise, deduped screen-reader announcement of a data refresh. The
+         * #recent-calls-status region is aria-live=polite; we only rewrite it when
+         * the summary changes so a quiet 5s poll stays quiet for AT users.
+         */
+        function announceCallsStatus(count) {
+            const statusEl = document.getElementById('recent-calls-status');
+            if (!statusEl) return;
+            const msg = count
+                ? `Call list updated. Showing ${count} of ${currentCallsTotal} calls, page ${currentCallsPage} of ${totalCallsPages}.`
+                : 'Call list updated. No calls match the current filters.';
+            if (msg !== lastCallsAnnouncement) {
+                statusEl.textContent = msg;
+                lastCallsAnnouncement = msg;
+            }
+        }
+
+        /**
+         * Wire the sortable recent-calls headers (Call ID, Received) to the API sort
+         * params. Static markup, so this runs once at init. Updates aria-sort + the
+         * visual indicator and reloads page 1.
+         */
+        function setupSortableHeaders() {
+            const headers = Array.from(document.querySelectorAll('th.sortable[data-sort-key]'));
+            if (!headers.length) return;
+
+            function reflect() {
+                headers.forEach(function (h) {
+                    const isActive = h.getAttribute('data-sort-key') === currentSortKey;
+                    h.setAttribute('aria-sort', isActive
+                        ? (currentSortOrder === 'asc' ? 'ascending' : 'descending')
+                        : 'none');
+                    const ind = h.querySelector('.sort-ind');
+                    if (ind) ind.textContent = isActive
+                        ? (currentSortOrder === 'asc' ? '▲' : '▼')
+                        : '↕';
+                });
+            }
+
+            headers.forEach(function (th) {
+                function activate() {
+                    const key = th.getAttribute('data-sort-key');
+                    if (currentSortKey === key) {
+                        currentSortOrder = currentSortOrder === 'asc' ? 'desc' : 'asc';
+                    } else {
+                        currentSortKey = key;
+                        currentSortOrder = 'asc';
+                    }
+                    reflect();
+                    loadRecentCalls(1);
+                }
+                th.addEventListener('click', activate);
+                th.addEventListener('keydown', function (e) {
+                    if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+                        e.preventDefault();
+                        activate();
+                    }
+                });
+            });
+
+            reflect(); // show the default create_datetime/desc sort on load
         }
         
         /**
@@ -1354,6 +1440,7 @@
         
         // Initial load
         console.log('[Dashboard Main] Starting initial load...');
+        setupSortableHeaders();
         await refreshDashboard();
         
         // Auto-refresh

--- a/public/assets/js/dashboard.js
+++ b/public/assets/js/dashboard.js
@@ -142,15 +142,22 @@ const Dashboard = {
         const toast = document.createElement('div');
         toast.className = `alert alert-${this.escapeHtml(type)} alert-dismissible fade show position-fixed`;
         toast.style.cssText = 'top: 20px; right: 20px; z-index: 9999; min-width: 300px;';
-        
+
+        // Announce to assistive tech: assertive for warning/danger, polite otherwise.
+        const assertive = (type === 'danger' || type === 'warning');
+        toast.setAttribute('role', assertive ? 'alert' : 'status');
+        toast.setAttribute('aria-live', assertive ? 'assertive' : 'polite');
+        toast.setAttribute('aria-atomic', 'true');
+
         // Create text node for message (safe) and button separately
         const textNode = document.createTextNode(message);
         toast.appendChild(textNode);
-        
+
         const closeBtn = document.createElement('button');
         closeBtn.type = 'button';
         closeBtn.className = 'btn-close';
         closeBtn.setAttribute('data-bs-dismiss', 'alert');
+        closeBtn.setAttribute('aria-label', 'Close');
         toast.appendChild(closeBtn);
         
         document.body.appendChild(toast);

--- a/public/assets/js/filters/FilterPanel.js
+++ b/public/assets/js/filters/FilterPanel.js
@@ -113,8 +113,16 @@
 
   FilterPanel.prototype._scheduleApply = function () {
     clearTimeout(this.applyTimer);
+    this._setBusy(true);
     const self = this;
     this.applyTimer = setTimeout(function () { self._apply(); }, 250);
+  };
+
+  FilterPanel.prototype._setBusy = function (busy) {
+    if (!this.root) return;
+    this.root.classList.toggle('filter-panel--applying', busy);
+    if (busy) this.root.setAttribute('aria-busy', 'true');
+    else this.root.removeAttribute('aria-busy');
   };
 
   FilterPanel.prototype._apply = function () {
@@ -123,7 +131,19 @@
     window.history.replaceState({}, '', url);
     localStorage.setItem('filter-panel:last-state', JSON.stringify(this.state.snapshot()));
     this._announce();
-    this.onChange(this.state);
+    const self = this;
+    let result;
+    try {
+      result = this.onChange(this.state);
+    } finally {
+      // Clear the busy affordance once the consumer's apply settles. onChange
+      // may be sync (clear now) or return a promise (clear when it resolves).
+      if (result && typeof result.then === 'function') {
+        result.then(function () { self._setBusy(false); }, function () { self._setBusy(false); });
+      } else {
+        this._setBusy(false);
+      }
+    }
   };
 
   FilterPanel.prototype._announce = function () {

--- a/public/assets/js/filters/fields/DateRangeField.js
+++ b/public/assets/js/filters/fields/DateRangeField.js
@@ -19,8 +19,10 @@
 
   DateRangeField.prototype.mount = function (rootEl, opts) {
     rootEl.innerHTML = '';
+    const inputId = 'ff-' + this.name + '-range';
     const labelEl = document.createElement('label');
     labelEl.textContent = this.label;
+    labelEl.htmlFor = inputId;
     rootEl.appendChild(labelEl);
 
     const presetSelect = document.createElement('select');
@@ -35,6 +37,10 @@
 
     const input = document.createElement('input');
     input.type = 'text';
+    input.id = inputId;
+    // Accessible name via the associated <label htmlFor>; aria-label is a
+    // fallback for when Flatpickr swaps in an alt input that loses the id link.
+    input.setAttribute('aria-label', this.label + ' range (YYYY-MM-DD to YYYY-MM-DD)');
     input.placeholder = 'YYYY-MM-DD to YYYY-MM-DD';
     rootEl.appendChild(input);
 

--- a/public/assets/js/filters/filters.css
+++ b/public/assets/js/filters/filters.css
@@ -139,6 +139,7 @@
 
 /* Header row: label on left, reset on right; spans full grid */
 .filter-panel-header {
+  position: relative;               /* anchor for the busy affordance */
   grid-column: 1 / -1;
   display: flex;
   justify-content: space-between;
@@ -148,13 +149,49 @@
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 }
 
+/* ------------------------------------------------------------------ */
+/* Busy affordance during the debounced apply                          */
+/* ------------------------------------------------------------------ */
+
+/* A subtle centered spinner shown while .filter-panel--applying is set.
+   aria-busy on the panel root carries the state for assistive tech. */
+.filter-panel-header::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: calc(50% - 0.375rem);        /* offset up for the header's bottom padding */
+  width: 0.85rem;
+  height: 0.85rem;
+  margin: -0.425rem 0 0 -0.425rem;
+  border: 2px solid rgba(13, 110, 253, 0.25);
+  border-top-color: #0d6efd;
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+}
+.filter-panel--applying .filter-panel-header::after {
+  opacity: 1;
+  animation: filter-panel-spin 0.6s linear infinite;
+}
+
+@keyframes filter-panel-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .filter-panel--applying .filter-panel-header::after {
+    animation: none;                /* keep the static ring, no rotation */
+  }
+}
+
 .filter-panel-header::before {
   content: 'Refine your view';
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #6c757d;
+  color: var(--text-muted-accessible);
 }
 
 .filter-panel-reset {
@@ -197,7 +234,7 @@
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: #6c757d;
+  color: var(--text-muted-accessible);
   margin: 0;
 }
 
@@ -242,7 +279,7 @@
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: #6c757d;
+  color: var(--text-muted-accessible);
 }
 
 .filter-panel-field--status > :not(.filter-panel-label) {

--- a/public/assets/js/maps.js
+++ b/public/assets/js/maps.js
@@ -82,15 +82,21 @@ const MapManager = {
         
         // Choose marker color class based on priority. Styles live in dashboard.css
         // because CSP style-src no longer allows inline style="" attributes.
+        // Accessibility: render the priority NUMBER as text inside the circle so the
+        // marker does not convey priority by color alone (colorblind-safe). The class
+        // structure (.custom-marker .marker-circle) is preserved for dashboard.css.
         const colorClass = this.getCallIconColorClass(call.priority);
+        const priorityLabel = this.getPriorityLabel(call.priority);
+        const callType = call.call_types?.[0] || call.call_type || call.nature_of_call || 'call';
+        const markerTitle = `Priority ${priorityLabel} call — ${callType}`;
         const icon = L.divIcon({
             className: 'custom-marker',
-            html: `<div class="marker-circle ${colorClass}"><i class="bi bi-telephone-fill"></i></div>`,
+            html: `<div class="marker-circle ${colorClass}" role="img" aria-label="${Dashboard.escapeHtml(markerTitle)}" title="${Dashboard.escapeHtml(markerTitle)}"><span class="marker-priority">${Dashboard.escapeHtml(priorityLabel)}</span></div>`,
             iconSize: [30, 30],
             iconAnchor: [15, 15]
         });
-        
-        const marker = L.marker([lat, lon], { icon })
+
+        const marker = L.marker([lat, lon], { icon, title: markerTitle, alt: markerTitle })
             .bindPopup(call.popupContent || this.createCallPopup(call))
             .addTo(this.markers[containerId]);
         
@@ -110,6 +116,16 @@ const MapManager = {
             4: 'marker-circle--green'    // Low
         };
         return classes[priority] || 'marker-circle--gray';
+    },
+
+    /**
+     * Get a short, non-color priority label (the digit 1-5) for the marker glyph.
+     * Colorblind users read the number instead of relying on the circle color.
+     * Falls back to "?" when priority is missing or unrecognized.
+     */
+    getPriorityLabel(priority) {
+        const n = parseInt(priority, 10);
+        return (Number.isFinite(n) && n >= 1 && n <= 5) ? String(n) : '?';
     },
 
 

--- a/public/assets/js/maps.js
+++ b/public/assets/js/maps.js
@@ -85,8 +85,12 @@ const MapManager = {
         // Accessibility: render the priority NUMBER as text inside the circle so the
         // marker does not convey priority by color alone (colorblind-safe). The class
         // structure (.custom-marker .marker-circle) is preserved for dashboard.css.
-        const colorClass = this.getCallIconColorClass(call.priority);
-        const priorityLabel = this.getPriorityLabel(call.priority);
+        // The /api/calls list payload exposes numeric priority as `alarm_level`
+        // (with a `priorities[]` list), not `priority`. Derive from those so the
+        // marker colour + numeral are correct instead of always gray / "?".
+        const derivedPriority = parseInt(call.alarm_level ?? call.priorities?.[0] ?? call.priority, 10);
+        const colorClass = this.getCallIconColorClass(derivedPriority);
+        const priorityLabel = this.getPriorityLabel(derivedPriority);
         const callType = call.call_types?.[0] || call.call_type || call.nature_of_call || 'call';
         const markerTitle = `Priority ${priorityLabel} call — ${callType}`;
         const icon = L.divIcon({

--- a/public/assets/js/mobile.js
+++ b/public/assets/js/mobile.js
@@ -56,8 +56,9 @@ const MobileDashboard = {
                 onChange: (state) => {
                     this.currentQs = state.toQueryString();
                     this.currentPage = 1;
-                    this.loadCallsList();
-                    this.loadStats();
+                    // Return the combined refresh promise so FilterPanel holds its
+                    // busy/aria-busy state until both requests settle.
+                    return Promise.all([this.loadCallsList(), this.loadStats()]);
                 },
             });
             await this.panel.mount();

--- a/public/index.php
+++ b/public/index.php
@@ -69,13 +69,16 @@ $pageTitle = ucfirst(str_replace('-mobile', '', $page));
     <link href="/assets/css/print.css" rel="stylesheet" media="print">
 </head>
 <body<?= $isMobile ? ' class="mobile-view"' : '' ?>>
+    <!-- Skip link (keyboard users bypass the nav) -->
+    <a class="skip-link" href="#main-content">Skip to main content</a>
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
         <div class="container-fluid">
             <a class="navbar-brand" href="/">
                 <i class="bi bi-broadcast"></i> NWS CAD Dashboard
             </a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+                    aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
@@ -97,8 +100,8 @@ $pageTitle = ucfirst(str_replace('-mobile', '', $page));
                     </li>
                 </ul>
                 <div class="d-flex align-items-center">
-                    <span class="live-pill" id="dashboard-live-pill">
-                        <span class="dot"></span>
+                    <span class="live-pill" id="dashboard-live-pill" role="status" aria-live="polite">
+                        <span class="dot" aria-hidden="true"></span>
                         <span id="dashboard-live-text">Live</span>
                     </span>
                 </div>
@@ -107,7 +110,7 @@ $pageTitle = ucfirst(str_replace('-mobile', '', $page));
     </nav>
 
     <!-- Main Content -->
-    <main class="container-fluid py-4">
+    <main id="main-content" tabindex="-1" class="container-fluid py-4">
         <?php
         $viewFile = __DIR__ . "/../src/Dashboard/Views/{$page}.php";
         if (file_exists($viewFile)) {

--- a/src/Dashboard/Views/dashboard.php
+++ b/src/Dashboard/Views/dashboard.php
@@ -3,7 +3,7 @@
 <!-- Dashboard Header (gradient banner) -->
 <div class="dashboard-banner d-flex justify-content-between align-items-center flex-wrap gap-2">
     <div>
-        <h2><i class="bi bi-speedometer2"></i> Dashboard Control Center</h2>
+        <h1 class="h3 mb-0"><i class="bi bi-speedometer2"></i> Dashboard Control Center</h1>
         <div class="subtitle">Live call data &middot; refreshes every <span id="dashboard-poll-secs">5</span>s</div>
     </div>
     <div class="d-flex align-items-center gap-2">

--- a/src/Dashboard/Views/partials/analytics-modal.php
+++ b/src/Dashboard/Views/partials/analytics-modal.php
@@ -109,7 +109,10 @@
                                 </h5>
                             </div>
                             <div class="card-body">
-                                <canvas id="analytics-volume-chart"></canvas>
+                                <canvas id="analytics-volume-chart" role="img"
+                                        data-chart-title="Incidents by jurisdiction"
+                                        aria-label="Incidents by jurisdiction chart. Loading data."></canvas>
+                                <div id="analytics-volume-chart-summary" class="visually-hidden"></div>
                             </div>
                         </div>
                     </div>
@@ -122,7 +125,10 @@
                                 </h5>
                             </div>
                             <div class="card-body">
-                                <canvas id="analytics-distribution-chart"></canvas>
+                                <canvas id="analytics-distribution-chart" role="img"
+                                        data-chart-title="Call distribution by type"
+                                        aria-label="Call distribution by type chart. Loading data."></canvas>
+                                <div id="analytics-distribution-chart-summary" class="visually-hidden"></div>
                             </div>
                         </div>
                     </div>
@@ -138,7 +144,10 @@
                                 </h5>
                             </div>
                             <div class="card-body">
-                                <canvas id="analytics-response-chart"></canvas>
+                                <canvas id="analytics-response-chart" role="img"
+                                        data-chart-title="Response time analysis"
+                                        aria-label="Response time analysis chart. Loading data."></canvas>
+                                <div id="analytics-response-chart-summary" class="visually-hidden"></div>
                             </div>
                         </div>
                     </div>
@@ -151,7 +160,10 @@
                                 </h5>
                             </div>
                             <div class="card-body">
-                                <canvas id="analytics-agency-chart"></canvas>
+                                <canvas id="analytics-agency-chart" role="img"
+                                        data-chart-title="Calls by agency"
+                                        aria-label="Calls by agency chart. Loading data."></canvas>
+                                <div id="analytics-agency-chart-summary" class="visually-hidden"></div>
                             </div>
                         </div>
                     </div>

--- a/src/Dashboard/Views/partials/map-and-stats.php
+++ b/src/Dashboard/Views/partials/map-and-stats.php
@@ -5,10 +5,10 @@
             <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
-                        <h6 class="text-muted mb-1">Total Calls</h6>
-                        <h2 class="mb-0" id="stat-total-calls">
+                        <div class="stat-label text-muted mb-1">Total Calls</div>
+                        <div class="stat-value tabular-nums mb-0" id="stat-total-calls">
                             <span class="spinner-border spinner-border-sm"></span>
-                        </h2>
+                        </div>
                         <span class="summary-chips mt-1" id="stat-total-pill"></span>
                     </div>
                     <div class="stat-icon">
@@ -24,10 +24,10 @@
             <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
-                        <h6 class="text-muted mb-1">Active Calls</h6>
-                        <h2 class="mb-0 text-danger" id="stat-active-calls">
+                        <div class="stat-label text-muted mb-1">Active Calls</div>
+                        <div class="stat-value tabular-nums mb-0 text-danger" id="stat-active-calls">
                             <span class="spinner-border spinner-border-sm"></span>
-                        </h2>
+                        </div>
                         <span class="summary-chips mt-1" id="stat-active-pill"></span>
                     </div>
                     <div class="stat-icon">
@@ -43,10 +43,10 @@
             <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
-                        <h6 class="text-muted mb-1">Closed Calls</h6>
-                        <h2 class="mb-0" id="stat-closed-calls">
+                        <div class="stat-label text-muted mb-1">Closed Calls</div>
+                        <div class="stat-value tabular-nums mb-0" id="stat-closed-calls">
                             <span class="spinner-border spinner-border-sm"></span>
-                        </h2>
+                        </div>
                         <span class="summary-chips mt-1" id="stat-closed-pill"></span>
                     </div>
                     <div class="stat-icon">
@@ -62,10 +62,10 @@
             <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
-                        <h6 class="text-muted mb-1">Analytics</h6>
-                        <h2 class="mb-0 stat-title-compact">
+                        <div class="stat-label text-muted mb-1">Analytics</div>
+                        <div class="stat-value stat-title-compact mb-0">
                             <i class="bi bi-graph-up"></i> View Charts
-                        </h2>
+                        </div>
                         <span class="summary-chips mt-1" id="stat-analytics-pill"></span>
                     </div>
                     <div class="stat-icon">
@@ -83,13 +83,21 @@
     <div class="col-lg-5 mb-3">
         <div class="card map-column-card">
             <div class="card-header gradient-card-header d-flex justify-content-between align-items-center">
-                <h5 class="card-title mb-0">
+                <h2 class="card-title h5 mb-0">
                     <i class="bi bi-geo-alt"></i> Madison County Map
-                </h5>
+                </h2>
                 <span class="pill-badge is-info" id="map-marker-count">0 markers</span>
             </div>
             <div class="card-body p-0">
                 <div id="calls-map"></div>
+            </div>
+            <div class="map-legend" role="group" aria-label="Call priority legend, 1 is highest">
+                <span class="legend-label">Priority (1 = highest):</span>
+                <span class="legend-item"><span class="legend-swatch marker-circle--red" aria-hidden="true">1</span>1</span>
+                <span class="legend-item"><span class="legend-swatch marker-circle--yellow" aria-hidden="true">2</span>2</span>
+                <span class="legend-item"><span class="legend-swatch marker-circle--blue" aria-hidden="true">3</span>3</span>
+                <span class="legend-item"><span class="legend-swatch marker-circle--green" aria-hidden="true">4</span>4</span>
+                <span class="legend-item"><span class="legend-swatch marker-circle--gray" aria-hidden="true">5</span>5</span>
             </div>
         </div>
     </div>
@@ -98,24 +106,24 @@
     <div class="col-lg-7 dashboard-right-col">
         <div class="card recent-calls-card">
             <div class="card-header gradient-card-header d-flex justify-content-between align-items-center">
-                <h5 class="card-title mb-0">
+                <h2 class="card-title h5 mb-0">
                     <i class="bi bi-list-ul"></i> <span id="recent-calls-title">Recent Calls</span>
-                </h5>
+                </h2>
                 <small>Last updated: <span id="last-updated">Never</span></small>
             </div>
             <div class="card-body p-0">
                 <div class="table-responsive recent-calls-scroll">
-                    <table class="table table-hover mb-0">
+                    <table class="table table-hover mb-0 tabular-nums">
                         <thead class="table-light sticky-top">
                             <tr>
-                                <th class="col-w-9">Call ID</th>
-                                <th class="col-w-13">Received</th>
-                                <th class="col-w-20">Call Type</th>
-                                <th class="col-w-19">Location</th>
-                                <th class="col-w-10">Priority</th>
-                                <th class="col-w-10">Status</th>
-                                <th class="col-w-9">Units</th>
-                                <th class="col-w-10">Map</th>
+                                <th scope="col" class="col-w-9 sortable" data-sort-key="call_number" aria-sort="none" tabindex="0">Call ID <span class="sort-ind" aria-hidden="true">&#8597;</span></th>
+                                <th scope="col" class="col-w-13 sortable" data-sort-key="create_datetime" aria-sort="none" tabindex="0">Received <span class="sort-ind" aria-hidden="true">&#8597;</span></th>
+                                <th scope="col" class="col-w-20">Call Type</th>
+                                <th scope="col" class="col-w-19">Location</th>
+                                <th scope="col" class="col-w-10">Priority</th>
+                                <th scope="col" class="col-w-10">Status</th>
+                                <th scope="col" class="col-w-9">Units</th>
+                                <th scope="col" class="col-w-10">Map</th>
                             </tr>
                         </thead>
                         <tbody id="recent-calls-body">
@@ -130,6 +138,8 @@
                         </tbody>
                     </table>
                 </div>
+                <!-- Screen-reader announcement of live refreshes (concise summary, not the whole table) -->
+                <div id="recent-calls-status" class="visually-hidden" role="status" aria-live="polite"></div>
                 <!-- Pagination Controls -->
                 <div class="d-flex justify-content-between align-items-center p-3 border-top d-none" id="calls-pagination-container">
                     <div>


### PR DESCRIPTION
Implements the [UI/UX audit](https://github.com/k9barry/nws-cad) findings for the desktop dashboard. All 13 findings + the 4 gap items are addressed.

## 🔴 Accessibility
- **Live data announced** — deduped `aria-live` status region summarizes each refresh (no per-poll chatter); toasts → `role=alert`/`status`; live/paused pill → `role=status` live region.
- **Heading structure** — single `<h1>` (banner), `<h2>` section titles (visual size kept via `.h5`), and the stat *number-as-`<h2>`* anti-pattern replaced with non-heading `.stat-value`/`.stat-label`.
- **Keyboard** — recent-calls rows are `role=button` + `tabindex=0` + Enter/Space; skip-link → focusable `<main>`; `navbar-toggler` labeled.
- **Forms** — DateRange input associated to its label; filter apply shows `aria-busy` + spinner pending state.
- **Contrast** — muted text → WCAG-AA `--text-muted-accessible`.

## 🟠 Color is no longer the only signal
- **Map** — markers render the priority **number** (`role=img`/`aria-label`) + a **legend**.
- **Charts** — colorblind-safe **Okabe-Ito** palette; canvases get `role=img`/`aria-label` + a visually-hidden **data-table** summary.

## 🟡 Design tokens & polish
- Brand gradient, slate pills, muted text, and the categorical chart palette are now `:root` **custom properties** (charts.js reads `--cat-*` via `getComputedStyle`) — kills the duplicated raw hex.
- `tabular-nums` on refreshing numbers; `100vh` → `100dvh`; **Call ID / Received** headers sortable (`aria-sort`) wired to the API's real sort allowlist (`call_number`/`create_datetime` — the other columns aren't server-sortable, so they're intentionally not faked); inline row `style` moved to a CSS class (keeps `style-src` CSP strict).

## Verification
- `node --check` on all 6 JS files, `php -l` on all 4 PHP files — pass.
- Cross-file integration checked (canvas ids ↔ chart summaries, `--cat-*` tokens, marker class ↔ CSS).
- Rendered the changed CSS + markup in a static harness; accessibility tree confirms skip-link, single h1 → h2 sections, legend group, and `button` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)