### PR TITLE
feat(deploy): self-hosted CD pipeline + compose stack hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,24 @@ WATCHER_FILE_PATTERN=*.xml
 DOZZLE_PORT=8081
 
 # =============================================================================
+# Host port exposure & self-healing (compose hardening)
+# =============================================================================
+# Host interface the published ports (API, DB, Dozzle) bind to.
+#   0.0.0.0     — all interfaces (default; unchanged from prior releases)
+#   127.0.0.1   — loopback only; recommended for production so only a
+#                 co-located reverse proxy (and SSH tunnels) can reach them.
+# The app-level TrustedProxy guard runs regardless of this setting; loopback
+# binding is defense-in-depth at the socket layer. See docs/deployment/README.md.
+BIND_ADDR=0.0.0.0
+
+# Autoheal restarts any container labeled autoheal=true (app, api, mysql,
+# postgres) when Docker reports its healthcheck unhealthy — covering wedged
+# processes that don't exit (stale watcher heartbeat, hung DB ping).
+AUTOHEAL_INTERVAL=10
+AUTOHEAL_START_PERIOD=60
+AUTOHEAL_DEFAULT_STOP_TIMEOUT=30
+
+# =============================================================================
 # Security (v1.3.0 — security hardening)
 # =============================================================================
 # TrustedProxy::guard() rejects any request whose REMOTE_ADDR isn't in this list.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,15 +84,28 @@ jobs:
             exit 0
           fi
 
-          # workflow_run after Release: only deploy if a version was actually
-          # cut, i.e. the tip of main is the release commit that Release pushes.
+          # workflow_run after Release: deploy only when a version was actually
+          # cut on this run — i.e. the newest v* tag points at the CURRENT tip of
+          # main AND that tip is the `chore(release):` commit Release pushes.
+          # Keying off tag→tip identity (not just the tip's subject) makes the
+          # decision deterministic: if main advanced past the release commit
+          # before this gate ran, TAG_SHA != HEAD_SHA and we safely decline
+          # rather than resolve a stale/wrong tag.
+          #
+          # NOTE: github.event.workflow_run.head_sha is deliberately NOT used —
+          # it is the PRE-release commit that triggered Release; Release then
+          # creates the release commit + tag as a CHILD of it, so head_sha never
+          # carries the release commit or the tag.
           SUBJECT="$(git log -1 --pretty=%s)"
-          if printf '%s' "$SUBJECT" | grep -qE '^chore\(release\): v'; then
-            echo "Release commit at tip of main: '$SUBJECT' -> deploying '$LATEST_TAG'."
+          HEAD_SHA="$(git rev-parse HEAD)"
+          TAG_SHA="$(git rev-list -n1 "$LATEST_TAG" 2>/dev/null || echo '')"
+          if [ -n "$LATEST_TAG" ] && [ "$TAG_SHA" = "$HEAD_SHA" ] \
+             && printf '%s' "$SUBJECT" | grep -qE '^chore\(release\): v'; then
+            echo "Fresh release $LATEST_TAG at tip of main -> deploying."
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"
             echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
           else
-            echo "Tip of main is not a release commit ('$SUBJECT') — no deploy."
+            echo "No fresh release at tip of main (tip='$SUBJECT', latest tag='$LATEST_TAG') — no deploy."
             echo "should_deploy=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,129 @@
+name: Deploy
+
+# Continuous deployment to the production host.
+#
+# Trigger model
+# -------------
+# The Release workflow creates the v* tag + GitHub Release using GITHUB_TOKEN,
+# and GitHub never fires `push:tags` / `release:published` from GITHUB_TOKEN
+# activity. So we hang CD off `workflow_run` (fires when "Release" finishes,
+# regardless of token) plus a manual `workflow_dispatch` for on-demand deploys
+# and rollbacks.
+#
+# Two jobs:
+#   gate   — github-hosted, no approval. Decides whether a release was actually
+#            cut (tip of main is a `chore(release): vX.Y.Z` commit) and resolves
+#            the tag. On a no-release push to main this outputs should_deploy=false
+#            so the gated job below never runs (and never asks for approval).
+#   deploy — self-hosted runner ON the host, gated by the `production`
+#            Environment (required reviewer). Runs scripts/deploy.sh against the
+#            on-host clone at ${{ vars.DEPLOY_DIR }}.
+#
+# One-time setup lives in docs/deployment/CD.md (runner label `nws-cad`,
+# the `production` Environment + reviewer, and the DEPLOY_DIR variable).
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag/ref to deploy (default: latest v* tag)'
+        required: false
+        default: ''
+      force:
+        description: 'Redeploy even if already on the target commit'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: Decide whether to deploy
+    # Skip entirely on a failed Release run; always evaluate manual dispatches.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.decide.outputs.should_deploy }}
+      tag: ${{ steps.decide.outputs.tag }}
+    steps:
+      - name: Checkout main (full history + tags)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Decide
+        id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_REF: ${{ github.event.inputs.ref }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force origin >/dev/null 2>&1 || true
+          LATEST_TAG="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo '')"
+
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            TAG="${INPUT_REF:-$LATEST_TAG}"
+            if [ -z "$TAG" ]; then
+              echo "::error::No ref supplied and no v* tag found."; exit 1
+            fi
+            echo "Manual dispatch -> deploying '$TAG'."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # workflow_run after Release: only deploy if a version was actually
+          # cut, i.e. the tip of main is the release commit that Release pushes.
+          SUBJECT="$(git log -1 --pretty=%s)"
+          if printf '%s' "$SUBJECT" | grep -qE '^chore\(release\): v'; then
+            echo "Release commit at tip of main: '$SUBJECT' -> deploying '$LATEST_TAG'."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tip of main is not a release commit ('$SUBJECT') — no deploy."
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    name: Deploy to production
+    needs: gate
+    if: needs.gate.outputs.should_deploy == 'true'
+    runs-on: [self-hosted, nws-cad]
+    environment: production
+    steps:
+      - name: Validate on-host deploy directory
+        env:
+          DEPLOY_DIR: ${{ vars.DEPLOY_DIR }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DEPLOY_DIR:-}" ]; then
+            echo "::error::Set the DEPLOY_DIR variable (repo or 'production' Environment) to the on-host clone path, e.g. /opt/nws-cad"
+            exit 1
+          fi
+          [ -d "$DEPLOY_DIR/.git" ] || { echo "::error::DEPLOY_DIR '$DEPLOY_DIR' is not a git clone"; exit 1; }
+          [ -f "$DEPLOY_DIR/.env" ] || { echo "::error::DEPLOY_DIR '$DEPLOY_DIR' has no .env"; exit 1; }
+          [ -x "$DEPLOY_DIR/scripts/deploy.sh" ] || { echo "::error::$DEPLOY_DIR/scripts/deploy.sh missing or not executable"; exit 1; }
+
+      - name: Deploy ${{ needs.gate.outputs.tag }}
+        working-directory: ${{ vars.DEPLOY_DIR }}
+        env:
+          DEPLOY_TAG: ${{ needs.gate.outputs.tag }}
+          FORCE: ${{ github.event.inputs.force == 'true' && '1' || '0' }}
+        run: |
+          set -euo pipefail
+          echo "Deploying tag: $DEPLOY_TAG (FORCE=$FORCE)"
+          # deploy.sh fetches, backs up, checks out the tag, migrates, brings the
+          # stack up, verifies /api/health, and rolls back on any failure.
+          bash scripts/deploy.sh "$DEPLOY_TAG"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,7 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
           INPUT_REF: ${{ github.event.inputs.ref }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
           git fetch --tags --force origin >/dev/null 2>&1 || true
@@ -84,28 +85,34 @@ jobs:
             exit 0
           fi
 
-          # workflow_run after Release: deploy only when a version was actually
-          # cut on this run — i.e. the newest v* tag points at the CURRENT tip of
-          # main AND that tip is the `chore(release):` commit Release pushes.
-          # Keying off tag→tip identity (not just the tip's subject) makes the
-          # decision deterministic: if main advanced past the release commit
-          # before this gate ran, TAG_SHA != HEAD_SHA and we safely decline
-          # rather than resolve a stale/wrong tag.
+          # workflow_run after Release: deploy only the release THIS run produced,
+          # resolved deterministically from the triggering Release run's head SHA.
           #
-          # NOTE: github.event.workflow_run.head_sha is deliberately NOT used —
-          # it is the PRE-release commit that triggered Release; Release then
-          # creates the release commit + tag as a CHILD of it, so head_sha never
-          # carries the release commit or the tag.
-          SUBJECT="$(git log -1 --pretty=%s)"
-          HEAD_SHA="$(git rev-parse HEAD)"
-          TAG_SHA="$(git rev-list -n1 "$LATEST_TAG" 2>/dev/null || echo '')"
-          if [ -n "$LATEST_TAG" ] && [ "$TAG_SHA" = "$HEAD_SHA" ] \
-             && printf '%s' "$SUBJECT" | grep -qE '^chore\(release\): v'; then
-            echo "Fresh release $LATEST_TAG at tip of main -> deploying."
+          # Release runs on the pushed commit (workflow_run.head_sha), then creates
+          # the `chore(release): vX.Y.Z` commit as a DIRECT CHILD of it and tags
+          # that child. So the release this run cut is the v* tag whose commit's
+          # parent is exactly head_sha — a stable link that does NOT depend on
+          # where main's tip has since moved (addresses the moving-tip race). No
+          # such tag => the run was a no-release push (docs/chore) and we decline.
+          #
+          # head_sha itself is the PRE-release commit and never carries the tag
+          # (`git tag --points-at head_sha` is empty) — parentage is the correct
+          # link, not points-at.
+          RELEASE_TAG=""
+          while IFS= read -r t; do
+            [ -n "$t" ] || continue
+            tsha="$(git rev-list -n1 "$t" 2>/dev/null || echo '')"
+            [ -n "$tsha" ] || continue
+            psha="$(git rev-parse --verify --quiet "${tsha}^" || echo '')"
+            if [ "$psha" = "$RUN_HEAD_SHA" ]; then RELEASE_TAG="$t"; break; fi
+          done < <(git tag --list 'v*' --sort=-creatordate)
+
+          if [ -n "$RELEASE_TAG" ]; then
+            echo "Release $RELEASE_TAG was cut from ${RUN_HEAD_SHA} -> deploying."
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"
-            echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+            echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           else
-            echo "No fresh release at tip of main (tip='$SUBJECT', latest tag='$LATEST_TAG') — no deploy."
+            echo "Release run on ${RUN_HEAD_SHA} produced no v* tag (no-release push) — no deploy."
             echo "should_deploy=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,15 +2,13 @@
 
 Open work items not yet scheduled. Add new items at the top with a date.
 
-## 2026-05-08
+_No open items._
 
-- **Auto-restart unhealthy containers.** Today, `docker-compose.yml` uses
-  `restart: unless-stopped`, which only restarts containers on *exit*. If a
-  container's healthcheck flips to `unhealthy` but the process keeps running
-  (e.g. the watcher's heartbeat goes stale because of a deadlock, or the
-  `mysql` healthcheck fails while mysqld lingers), nothing kicks it.
-  Investigate adding `willfarrell/autoheal` (or equivalent) to the compose
-  stack so any container with `autoheal=true` label gets restarted when
-  Docker reports it unhealthy. Pair this with the existing watcher heartbeat
-  and `/api/health` endpoint so a wedged process actually gets recovered
-  without manual intervention.
+## Done
+
+- **Auto-restart unhealthy containers** (2026-05-08 → done 2026-07-12). Added a
+  `willfarrell/autoheal` sidecar to `docker-compose.yml` that restarts any
+  container labeled `autoheal=true` (`app`, `api`, `mysql`, `postgres`) when
+  Docker reports its healthcheck unhealthy. This covers wedged processes that
+  don't exit (stale watcher heartbeat, hung DB ping), which
+  `restart: unless-stopped` alone misses.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,11 @@
+# Shared container-log rotation caps so a chatty/looping service can't fill the
+# host disk. Applied to every service via the *default-logging alias.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   # PHP Application Service (File Watcher)
   app:
@@ -9,6 +17,11 @@ services:
         TZ: ${TZ:-UTC}
     container_name: nws-cad-app
     restart: unless-stopped
+    # Restarted by the `autoheal` service when the healthcheck below flips to
+    # unhealthy (e.g. watcher heartbeat goes stale but the process lingers).
+    labels:
+      - autoheal=true
+    logging: *default-logging
     working_dir: /var/www
     volumes:
       - ./:/var/www
@@ -63,8 +76,17 @@ services:
       args:
         TZ: ${TZ:-UTC}
     container_name: nws-cad-api
+    restart: unless-stopped
+    labels:
+      - autoheal=true
+    logging: *default-logging
+    # BIND_ADDR defaults to 0.0.0.0 (all interfaces, unchanged from prior
+    # releases). Set BIND_ADDR=127.0.0.1 in .env to publish loopback-only so
+    # only a co-located reverse proxy can reach the API (see
+    # docs/deployment/README.md — the app-level TrustedProxy guard still runs
+    # regardless).
     ports:
-      - "${API_PORT:-8080}:8080"
+      - "${BIND_ADDR:-0.0.0.0}:${API_PORT:-8080}:8080"
     volumes:
       - ./public:/var/www/public
       - ./src:/var/www/src
@@ -94,6 +116,9 @@ services:
     image: mysql:8.0
     container_name: nws-cad-mysql
     restart: unless-stopped
+    labels:
+      - autoheal=true
+    logging: *default-logging
     profiles:
       - mysql
     environment:
@@ -109,8 +134,10 @@ services:
       # override: docker compose -f docker-compose.yml -f docker-compose.test.yml \
       #   --profile mysql up -d   (see docker-compose.test.yml / docs/TESTING.md).
       - ./docker/mysql/my.cnf:/etc/mysql/conf.d/custom.cnf:ro
+    # Set BIND_ADDR=127.0.0.1 in .env to stop exposing the DB port on all host
+    # interfaces (recommended for production).
     ports:
-      - "${MYSQL_PORT:-3306}:3306"
+      - "${BIND_ADDR:-0.0.0.0}:${MYSQL_PORT:-3306}:3306"
     networks:
       - nws-cad-network
     healthcheck:
@@ -124,6 +151,9 @@ services:
     image: postgres:16
     container_name: nws-cad-postgres
     restart: unless-stopped
+    labels:
+      - autoheal=true
+    logging: *default-logging
     profiles:
       - pgsql
     environment:
@@ -134,8 +164,10 @@ services:
     volumes:
       - ${NWS_VAR_DIR:-./var}/data/postgres:/var/lib/postgresql/data
       - ./database/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
+    # Set BIND_ADDR=127.0.0.1 in .env to stop exposing the DB port on all host
+    # interfaces (recommended for production).
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "${BIND_ADDR:-0.0.0.0}:${POSTGRES_PORT:-5432}:5432"
     networks:
       - nws-cad-network
     healthcheck:
@@ -158,8 +190,11 @@ services:
     image: amir20/dozzle:latest
     container_name: nws-cad-dozzle
     restart: unless-stopped
+    logging: *default-logging
+    # Dozzle exposes container logs — keep it loopback-only in production by
+    # setting BIND_ADDR=127.0.0.1 (reach it via the reverse proxy / SSH tunnel).
     ports:
-      - "${DOZZLE_PORT:-8081}:8080"
+      - "${BIND_ADDR:-0.0.0.0}:${DOZZLE_PORT:-8081}:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./docker/dozzle/users.yml:/data/users.yml:ro
@@ -176,6 +211,33 @@ services:
       timeout: 30s
       retries: 5
       start_period: 30s
+
+  # Autoheal — restarts any container labeled `autoheal=true` when Docker
+  # reports its healthcheck as unhealthy. `restart: unless-stopped` only reacts
+  # to a *process exit*; this covers the case where a process lingers but its
+  # healthcheck fails (a wedged watcher whose heartbeat goes stale, or a DB
+  # whose ping fails while the daemon hangs). Watches labels only — no profile,
+  # so it runs for both mysql and pgsql deployments.
+  autoheal:
+    image: willfarrell/autoheal:latest
+    container_name: nws-cad-autoheal
+    restart: unless-stopped
+    logging: *default-logging
+    environment:
+      - TZ=${TZ:-UTC}
+      # Only touch containers we explicitly opted in via `autoheal=true`.
+      - AUTOHEAL_CONTAINER_LABEL=autoheal
+      # Poll interval (seconds) for checking container health.
+      - AUTOHEAL_INTERVAL=${AUTOHEAL_INTERVAL:-10}
+      # Grace window after a container starts before it's eligible for a restart.
+      - AUTOHEAL_START_PERIOD=${AUTOHEAL_START_PERIOD:-60}
+      # Give the container a clean stop before SIGKILL.
+      - AUTOHEAL_DEFAULT_STOP_TIMEOUT=${AUTOHEAL_DEFAULT_STOP_TIMEOUT:-30}
+    volumes:
+      # Needs the Docker API to issue restarts (read-write, unlike Dozzle).
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - nws-cad-network
 
 networks:
   nws-cad-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -219,7 +219,11 @@ services:
   # whose ping fails while the daemon hangs). Watches labels only — no profile,
   # so it runs for both mysql and pgsql deployments.
   autoheal:
-    image: willfarrell/autoheal:latest
+    # Pinned (not :latest) for reproducible deploys. This container has RW access
+    # to the Docker socket (required to issue restarts — see the volume note
+    # below), so it is highly privileged; pinning avoids silently pulling a
+    # changed upstream image. Bump deliberately; optionally add an @sha256 digest.
+    image: willfarrell/autoheal:1.2.0
     container_name: nws-cad-autoheal
     restart: unless-stopped
     logging: *default-logging

--- a/docs/deployment/CD.md
+++ b/docs/deployment/CD.md
@@ -1,0 +1,125 @@
+# Continuous deployment (GitHub Actions → self-hosted host)
+
+`.github/workflows/deploy.yml` deploys the stack to your production host after
+every release, gated by a manual approval. It is a thin trigger around
+`scripts/deploy.sh` — the same script you can run by hand on the host.
+
+## How it works
+
+```
+push to main ──▶ Release workflow ──▶ cuts vX.Y.Z tag + GitHub Release
+                                          │  (workflow_run: "Release" completed)
+                                          ▼
+                                   Deploy ▸ gate job  (github-hosted, no approval)
+                                          │  release commit at tip of main? → yes
+                                          ▼
+                                   Deploy ▸ deploy job (self-hosted, ON the host)
+                                          │  environment: production → waits for your ⏸ Approve
+                                          ▼
+                                   scripts/deploy.sh vX.Y.Z in $DEPLOY_DIR
+                                   backup → checkout → build → migrate → up → verify
+                                          │  any failure → automatic rollback
+                                          ▼
+                                   stack now running vX.Y.Z
+```
+
+**Why `workflow_run` and not `release: published`?** The Release workflow
+creates the tag and Release using `GITHUB_TOKEN`, and GitHub deliberately does
+**not** fire `push:tags` or `release:published` from `GITHUB_TOKEN` activity
+(the anti-recursion rule). `workflow_run` fires on the *Release workflow
+finishing*, independent of the token, so no personal access token is needed.
+
+**Why the `gate` job?** `workflow_run` fires after *every* push to main,
+including no-release pushes (docs, chores). The github-hosted `gate` job checks
+whether a version was actually cut — the tip of `main` is a
+`chore(release): vX.Y.Z` commit — and only then lets the gated `deploy` job run.
+This keeps the approval prompt from firing on pushes that produced no release.
+
+## One-time setup
+
+### 1. Register a self-hosted runner on the host
+
+The `deploy` job runs `runs-on: [self-hosted, nws-cad]`, so the runner needs the
+`nws-cad` label. On the production host:
+
+1. Repo → **Settings → Actions → Runners → New self-hosted runner**. Follow the
+   download/config steps GitHub shows.
+2. When prompted for labels, add **`nws-cad`** (the `self-hosted` label is
+   automatic).
+3. Run it as a service so it survives reboots:
+   ```bash
+   sudo ./svc.sh install
+   sudo ./svc.sh start
+   ```
+
+**Runner user prerequisites:**
+- Can run Docker without sudo — add it to the `docker` group
+  (`sudo usermod -aG docker <runner-user>`) and re-login.
+- Owns (or can read/write) the deploy directory and its `var/` tree.
+- The deploy directory is a **git clone with `origin` set to this repo** and can
+  `git fetch` (the runner's own GitHub auth does not extend to the clone — use a
+  read-only deploy key or HTTPS credentials on the host if the repo is private).
+
+### 2. Create the `production` Environment (the approval gate)
+
+Repo → **Settings → Environments → New environment → `production`**. Under
+**Deployment protection rules**, enable **Required reviewers** and add yourself.
+Now each deploy pauses in the Actions tab until you click **Approve**.
+
+> Prefer fully-automatic deploys instead? Delete the required-reviewer rule (or
+> remove `environment: production` from the `deploy` job). Everything else works
+> unchanged.
+
+### 3. Point CD at the on-host clone (`DEPLOY_DIR`)
+
+Set a **variable** (not a secret) named `DEPLOY_DIR` to the absolute path of the
+clone on the host — e.g. `/opt/nws-cad`. Either scope works:
+- Repo-wide: **Settings → Secrets and variables → Actions → Variables → New**.
+- Or scope it to the environment: **Settings → Environments → production →
+  Environment variables**.
+
+The self-hosted runner's own checkout directory is **not** the deploy directory
+— it has no `.env` and no `var/data`. The workflow deliberately ignores it and
+operates `$DEPLOY_DIR` instead, so your real config and database volumes are
+used.
+
+## Running it
+
+- **Automatic:** merge a releasable PR to `main`. Release cuts the tag, Deploy's
+  gate approves, and (with the gate on) the deploy waits for your **Approve** in
+  the Actions tab, then deploys.
+- **Manual / on-demand:** Actions → **Deploy → Run workflow**. Leave *ref* blank
+  for the latest tag, or type a specific tag.
+- **Rollback:** Actions → **Deploy → Run workflow**, set *ref* to the previous
+  good tag (e.g. `v2.0.3`) and *force* = true. `deploy.sh` checks that tag out,
+  rebuilds, and brings the stack up. (Note: migrations are additive/idempotent
+  and are **not** reversed — restore a DB backup if a schema rollback is needed;
+  see `docs/BACKUP_GUIDE.md`.)
+
+## Host fallback — run the deploy by hand
+
+CD just wraps the script; you can always deploy directly on the host:
+
+```bash
+cd /opt/nws-cad
+scripts/deploy.sh              # latest v* tag
+scripts/deploy.sh v2.0.4       # a specific tag
+FORCE=1 scripts/deploy.sh v2.0.3   # redeploy / roll back to a tag
+```
+
+`deploy.sh` automates `docs/deployment/RUNBOOK.md`: it fetches tags, backs up
+the DB (if running), checks out the target tag, builds, brings the DB up and
+waits for readiness, applies `database/migrations/*` for the active `DB_TYPE`,
+recreates the stack, and verifies `/api/health` — rolling back to the previous
+commit if any step fails. It is idempotent (no-op if already on the target,
+unless `FORCE=1`).
+
+## Security notes
+
+- No SSH exposure and no long-lived deploy keys in GitHub: the runner lives on
+  the host and pulls work from GitHub over its outbound connection.
+- The `production` environment scopes any deploy-only secrets/variables and the
+  approval gate to production alone.
+- Keep the runner user's Docker access in mind — membership in the `docker`
+  group is root-equivalent on that host. Use a dedicated, least-privilege
+  account for the runner.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -38,6 +38,13 @@ DB whose ping fails while the daemon hangs. Tunables: `AUTOHEAL_INTERVAL`
 (poll seconds), `AUTOHEAL_START_PERIOD` (post-start grace), and
 `AUTOHEAL_DEFAULT_STOP_TIMEOUT` (clean-stop window before SIGKILL).
 
+## Continuous deployment
+
+`scripts/deploy.sh` automates the runbook (backup → checkout tag → build →
+migrate → up → verify → rollback-on-failure) and can be run by hand on the host
+or driven by GitHub Actions. See **[CD.md](CD.md)** for the push-to-deploy setup
+(self-hosted runner + a `production` approval gate).
+
 ## Sample configurations
 
 See `caddy.example` and `nginx.example`. Both:

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -25,6 +25,18 @@ handles authentication and TLS termination. The application binds to
 | `PROXY_IDENTITY_HEADER` | `X-Auth-User` | Header read for the operator's username |
 | `NOTIFICATION_BASE_URL_ALLOWLIST` | (empty) | Comma-separated hostnames permitted as channel base URLs |
 | `NOTIFICATION_ALLOW_HTTP_PRIVATE` | `false` | Set `true` to permit `http://` for RFC1918 + loopback hosts only (testing) |
+| `BIND_ADDR` | `0.0.0.0` | Host interface the published ports (API, DB, Dozzle) bind to. Set `127.0.0.1` in production to publish loopback-only so only a co-located reverse proxy can reach them. |
+
+## Self-healing (autoheal)
+
+The compose stack runs a `willfarrell/autoheal` sidecar that restarts any
+container labeled `autoheal=true` (`app`, `api`, `mysql`, `postgres`) when
+Docker reports its healthcheck **unhealthy**. `restart: unless-stopped` only
+reacts to a process *exit*; autoheal covers the case where a process lingers
+but its healthcheck fails — a wedged watcher whose heartbeat goes stale, or a
+DB whose ping fails while the daemon hangs. Tunables: `AUTOHEAL_INTERVAL`
+(poll seconds), `AUTOHEAL_START_PERIOD` (post-start grace), and
+`AUTOHEAL_DEFAULT_STOP_TIMEOUT` (clean-stop window before SIGKILL).
 
 ## Sample configurations
 

--- a/docs/deployment/RUNBOOK.md
+++ b/docs/deployment/RUNBOOK.md
@@ -198,6 +198,10 @@ them. Put Caddy or nginx in front (samples in
 ---
 
 ### Notes
+- **Automating this runbook:** `scripts/deploy.sh [tag]` runs every step below
+  (backup → checkout → build → migrate → up → verify) with automatic rollback on
+  failure, and is idempotent. It can be driven by GitHub Actions for
+  push-to-deploy — see `docs/deployment/CD.md`.
 - **Self-healing:** the stack runs a `willfarrell/autoheal` sidecar that restarts any
   container whose healthcheck flips to **unhealthy** (`app`, `api`, `mysql`, `postgres`
   are labeled `autoheal=true`). This complements `restart: unless-stopped`, which only

--- a/docs/deployment/RUNBOOK.md
+++ b/docs/deployment/RUNBOOK.md
@@ -161,9 +161,10 @@ By default `docker-compose.yml` publishes the API on `${API_PORT:-8080}:8080`,
 which binds **all** host interfaces — access is not restricted at the socket.
 Enforcement is in the app: `TrustedProxy::guard()` rejects any request whose
 `REMOTE_ADDR` is outside `TRUSTED_PROXY_CIDRS` (default `127.0.0.1/32,::1/128`).
-For defense in depth, also restrict the published port to loopback by changing
-the `api` service's port mapping to `127.0.0.1:${API_PORT}:8080` so only the
-co-located proxy can reach it. Put Caddy or nginx in front (samples in
+For defense in depth, also restrict the published ports to loopback by setting
+`BIND_ADDR=127.0.0.1` in `.env` — this moves the API, DB, and Dozzle ports to
+`127.0.0.1` only, so just the co-located proxy (and SSH tunnels) can reach
+them. Put Caddy or nginx in front (samples in
 `docs/deployment/caddy.example` / `nginx.example`). The proxy must:
 - Terminate TLS and run HTTP Basic auth.
 - **Strip any inbound `X-Auth-User`** before auth, then set it to the authenticated user.
@@ -197,6 +198,10 @@ co-located proxy can reach it. Put Caddy or nginx in front (samples in
 ---
 
 ### Notes
+- **Self-healing:** the stack runs a `willfarrell/autoheal` sidecar that restarts any
+  container whose healthcheck flips to **unhealthy** (`app`, `api`, `mysql`, `postgres`
+  are labeled `autoheal=true`). This complements `restart: unless-stopped`, which only
+  reacts to a process *exit*. See `docs/deployment/README.md`.
 - Keep `WATCHER_INTERVAL` ≤ 30s (default 5s) or the 60s heartbeat healthcheck flaps.
 - `COMPOSE_PROFILES` must match `DB_TYPE`, or no database starts and `app`/`api` block on `service_healthy`.
 - This runbook supersedes the need for draft PR #38 (auto-migrate on startup): Step 4 applies the same migrations manually. If you prefer self-healing startup instead, that PR is the place to revive it.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+#
+# deploy.sh — self-service / CI deploy of the nws-cad stack to a target release.
+#
+# Automates docs/deployment/RUNBOOK.md end to end:
+#   pre-flight -> DB backup -> checkout target tag -> build -> DB up + wait ->
+#   apply migrations -> bring stack up -> verify health -> roll back on failure.
+#
+# Idempotent: re-running against the currently-deployed commit is a no-op
+# unless FORCE=1. Safe to run by hand on the host, or from the CD workflow
+# (.github/workflows/deploy.yml) on a self-hosted runner operating the on-host
+# clone (DEPLOY_DIR).
+#
+# Usage:
+#   scripts/deploy.sh [TARGET_REF]        # default: latest v* tag on origin
+#   scripts/deploy.sh v2.0.4
+#   FORCE=1 scripts/deploy.sh v2.0.4      # redeploy even if already on it
+#   SKIP_BACKUP=1 scripts/deploy.sh       # skip the pre-deploy DB backup
+#   SKIP_MIGRATIONS=1 scripts/deploy.sh   # bring the stack up without migrating
+#
+# Env knobs: FORCE, SKIP_BACKUP, SKIP_MIGRATIONS, HEALTH_TIMEOUT (default 180s).
+
+set -euo pipefail
+
+# --- Re-exec from a private copy --------------------------------------------
+# A mid-run `git checkout` rewrites this file in the working tree; bash reads
+# scripts lazily, so replacing $0 under a running shell can corrupt execution.
+# Copy ourselves to a tempfile and exec that, immune to the checkout below.
+if [ -z "${_DEPLOY_REEXEC:-}" ]; then
+    _orig="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+    _copy="$(mktemp "${TMPDIR:-/tmp}/nws-deploy.XXXXXX.sh")"
+    cp "$_orig" "$_copy"
+    export _DEPLOY_REEXEC=1 _DEPLOY_ORIG="$_orig" _DEPLOY_COPY="$_copy"
+    exec bash "$_copy" "$@"
+fi
+
+# Repo root is the parent of scripts/ (resolved from the ORIGINAL path, not the
+# tempfile copy), so compose finds docker-compose.yml/.env.
+REPO_ROOT="$(cd "$(dirname "${_DEPLOY_ORIG:-${BASH_SOURCE[0]}}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Output helpers ---------------------------------------------------------
+if [ -t 1 ]; then
+    GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; RED='\033[0;31m'; NC='\033[0m'
+else
+    GREEN=''; YELLOW=''; CYAN=''; RED=''; NC=''
+fi
+say()  { printf '%b%s%b\n' "$CYAN"   "$*" "$NC"; }
+ok()   { printf '%b%s%b\n' "$GREEN"  "$*" "$NC"; }
+warn() { printf '%b%s%b\n' "$YELLOW" "$*" "$NC" >&2; }
+err()  { printf '%b%s%b\n' "$RED"    "$*" "$NC" >&2; }
+
+# --- .env reader (last match wins; strips surrounding quotes) ----------------
+read_env() {
+    local key="$1" def="${2:-}" val=""
+    if [ -f .env ]; then
+        val="$(grep -E "^[[:space:]]*${key}=" .env | tail -n1 | cut -d= -f2- \
+            | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+                  -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'\$/\1/" || true)"
+    fi
+    printf '%s' "${val:-$def}"
+}
+
+# --- Resolve DB profile / compose command -----------------------------------
+DB_TYPE="${DB_TYPE:-$(read_env DB_TYPE mysql)}"
+case "$DB_TYPE" in
+    mysql|pgsql) ;;
+    *) err "DB_TYPE must be 'mysql' or 'pgsql' (got '$DB_TYPE')"; exit 1 ;;
+esac
+export COMPOSE_PROFILES="$DB_TYPE"
+if [ "$DB_TYPE" = pgsql ]; then DB_SVC=postgres; else DB_SVC=mysql; fi
+
+if docker compose version >/dev/null 2>&1; then
+    DC=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+    DC=(docker-compose)
+else
+    err "neither 'docker compose' nor 'docker-compose' is available."; exit 1
+fi
+
+# --- Config -----------------------------------------------------------------
+TARGET_REF="${1:-}"
+FORCE="${FORCE:-0}"
+SKIP_BACKUP="${SKIP_BACKUP:-0}"
+SKIP_MIGRATIONS="${SKIP_MIGRATIONS:-0}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
+BACKUP_DIR="$(read_env BACKUP_DIR ./var/backups)"
+
+DEPLOY_STARTED=0
+DEPLOY_OK=0
+
+# --- Functions --------------------------------------------------------------
+wait_for_db() {
+    local deadline=$(( $(date +%s) + 120 ))
+    if [ "$DB_TYPE" = mysql ]; then
+        local rootpw; rootpw="$(read_env MYSQL_ROOT_PASSWORD root_password)"
+        until docker exec nws-cad-mysql mysqladmin ping -u root -p"$rootpw" --silent >/dev/null 2>&1; do
+            [ "$(date +%s)" -lt "$deadline" ] || { err "MySQL not ready after 120s"; return 1; }
+            echo "  waiting for mysql..."; sleep 2
+        done
+    else
+        local pguser; pguser="$(read_env POSTGRES_USER nws_user)"
+        until docker exec nws-cad-postgres pg_isready -U "$pguser" >/dev/null 2>&1; do
+            [ "$(date +%s)" -lt "$deadline" ] || { err "Postgres not ready after 120s"; return 1; }
+            echo "  waiting for postgres..."; sleep 2
+        done
+    fi
+    ok "Database is accepting connections."
+}
+
+apply_migrations() {
+    local dir="database/migrations" f
+    [ -d "$dir" ] || { warn "No $dir directory; skipping migrations."; return 0; }
+    if [ "$DB_TYPE" = mysql ]; then
+        local rootpw db
+        rootpw="$(read_env MYSQL_ROOT_PASSWORD root_password)"
+        db="$(read_env MYSQL_DATABASE nws_cad)"
+        # MySQL migrations are *.sql, excluding the *.pgsql.sql Postgres variants.
+        for f in $(ls "$dir"/*.sql 2>/dev/null | grep -v '\.pgsql\.sql$' | sort); do
+            say "  migration: $f"
+            docker exec -i nws-cad-mysql mysql -u root -p"$rootpw" "$db" < "$f" \
+                || { err "Migration failed: $f"; return 1; }
+        done
+    else
+        local pguser pgdb
+        pguser="$(read_env POSTGRES_USER nws_user)"
+        pgdb="$(read_env POSTGRES_DB nws_cad)"
+        for f in $(ls "$dir"/*.pgsql.sql 2>/dev/null | sort); do
+            say "  migration: $f"
+            docker exec -i nws-cad-postgres psql -U "$pguser" -d "$pgdb" -v ON_ERROR_STOP=1 -f - < "$f" \
+                || { err "Migration failed: $f"; return 1; }
+        done
+    fi
+    ok "Migrations applied."
+}
+
+verify_health() {
+    local deadline=$(( $(date +%s) + HEALTH_TIMEOUT ))
+    # Hit the API from inside its own container so this is independent of the
+    # host port binding (BIND_ADDR) and reverse proxy.
+    until docker exec nws-cad-api curl -fsS -o /dev/null http://localhost:8080/api/health >/dev/null 2>&1; do
+        [ "$(date +%s)" -lt "$deadline" ] || { err "API health did not pass within ${HEALTH_TIMEOUT}s"; return 1; }
+        echo "  waiting for API health..."; sleep 3
+    done
+    ok "API health OK."
+    local unhealthy
+    unhealthy="$(docker ps --filter health=unhealthy --format '{{.Names}}' | grep '^nws-cad-' || true)"
+    [ -z "$unhealthy" ] || warn "Containers reporting unhealthy: $unhealthy"
+}
+
+rollback() {
+    err "Deploy failed — rolling back to ${PREV_DESC:-$PREV_SHA} ($PREV_SHA)."
+    git checkout --force "$PREV_SHA" >/dev/null 2>&1 || warn "  git rollback checkout failed."
+    "${DC[@]}" build >/dev/null 2>&1                 || warn "  rollback build failed."
+    "${DC[@]}" up -d --remove-orphans >/dev/null 2>&1 || warn "  rollback 'up' failed."
+    err "Rolled back to ${PREV_DESC:-$PREV_SHA}. Investigate before retrying."
+    err "Pre-deploy DB backup (if taken) is under: $BACKUP_DIR"
+}
+
+cleanup() {
+    local rc=$?
+    set +e
+    if [ "$DEPLOY_STARTED" = "1" ] && [ "$DEPLOY_OK" != "1" ]; then
+        rollback
+    fi
+    [ -n "${_DEPLOY_COPY:-}" ] && rm -f "$_DEPLOY_COPY"
+    exit "$rc"
+}
+trap cleanup EXIT
+
+# --- Pre-flight -------------------------------------------------------------
+command -v git >/dev/null    || { err "git not found"; exit 1; }
+command -v docker >/dev/null || { err "docker not found"; exit 1; }
+[ -f .env ]               || { err ".env not found in $REPO_ROOT"; exit 1; }
+[ -f docker-compose.yml ] || { err "docker-compose.yml not found in $REPO_ROOT"; exit 1; }
+[ -d .git ]               || { err "$REPO_ROOT is not a git clone"; exit 1; }
+
+# --- Resolve target ---------------------------------------------------------
+say "Fetching tags from origin..."
+git fetch --tags --prune origin
+
+if [ -z "$TARGET_REF" ]; then
+    TARGET_REF="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+    [ -n "$TARGET_REF" ] || { err "No target ref given and no v* tag found."; exit 1; }
+fi
+git rev-parse --verify --quiet "${TARGET_REF}^{commit}" >/dev/null \
+    || { err "Ref '$TARGET_REF' not found."; exit 1; }
+
+PREV_SHA="$(git rev-parse --short HEAD)"
+PREV_DESC="$(git describe --tags --always 2>/dev/null || echo "$PREV_SHA")"
+CURRENT_FULL="$(git rev-parse HEAD)"
+TARGET_FULL="$(git rev-parse "${TARGET_REF}^{commit}")"
+TARGET_SHA="$(git rev-parse --short "$TARGET_FULL")"
+
+if [ "$CURRENT_FULL" = "$TARGET_FULL" ] && [ "$FORCE" != "1" ]; then
+    ok "Already deployed at $TARGET_REF ($TARGET_SHA). Nothing to do (set FORCE=1 to redeploy)."
+    exit 0
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    warn "Working tree has uncommitted changes; checkout may fail. Commit/stash on the host if so."
+fi
+
+say "Deploying ${PREV_DESC} (${PREV_SHA}) -> ${TARGET_REF} (${TARGET_SHA})   [DB=${DB_TYPE}]"
+
+# --- Backup (only if a DB container is already running) ---------------------
+if [ "$SKIP_BACKUP" != "1" ]; then
+    if docker ps --format '{{.Names}}' | grep -q "^nws-cad-${DB_SVC}$"; then
+        say "Backing up database before deploy..."
+        if [ -x scripts/backup-database.sh ]; then
+            scripts/backup-database.sh || { err "Backup failed; aborting deploy (nothing changed yet)."; exit 1; }
+        else
+            warn "scripts/backup-database.sh missing/not executable; skipping backup."
+        fi
+    else
+        warn "DB container nws-cad-${DB_SVC} not running; skipping backup (fresh install?)."
+    fi
+fi
+
+# --- Deploy (rollback-guarded from here) ------------------------------------
+DEPLOY_STARTED=1
+
+say "Checking out ${TARGET_REF}..."
+git checkout --force "$TARGET_REF"
+
+say "Building images (with --pull)..."
+"${DC[@]}" build --pull
+
+say "Starting database (${DB_SVC}) and waiting for readiness..."
+"${DC[@]}" up -d "$DB_SVC"
+wait_for_db
+
+if [ "$SKIP_MIGRATIONS" != "1" ]; then
+    say "Applying migrations..."
+    apply_migrations
+else
+    warn "SKIP_MIGRATIONS=1 — not applying migrations."
+fi
+
+say "Bringing up the full stack..."
+"${DC[@]}" up -d --force-recreate --remove-orphans
+
+say "Verifying health (timeout ${HEALTH_TIMEOUT}s)..."
+verify_health
+
+DEPLOY_OK=1
+ok "Deploy complete — now running ${TARGET_REF} (${TARGET_SHA})."
+"${DC[@]}" ps

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -109,29 +109,42 @@ wait_for_db() {
 }
 
 apply_migrations() {
-    local dir="database/migrations" f
+    local dir="database/migrations" f applied=0
     [ -d "$dir" ] || { warn "No $dir directory; skipping migrations."; return 0; }
+    # nullglob: a non-matching glob expands to nothing (not the literal pattern),
+    # so an empty migration set is a clean no-op. Glob expansion is lexically
+    # sorted, which matches the date-prefixed migration filenames. Avoids parsing
+    # `ls` output entirely.
+    shopt -s nullglob
     if [ "$DB_TYPE" = mysql ]; then
         local rootpw db
         rootpw="$(read_env MYSQL_ROOT_PASSWORD root_password)"
         db="$(read_env MYSQL_DATABASE nws_cad)"
         # MySQL migrations are *.sql, excluding the *.pgsql.sql Postgres variants.
-        for f in $(ls "$dir"/*.sql 2>/dev/null | grep -v '\.pgsql\.sql$' | sort); do
+        for f in "$dir"/*.sql; do
+            case "$f" in *.pgsql.sql) continue ;; esac
             say "  migration: $f"
             docker exec -i nws-cad-mysql mysql -u root -p"$rootpw" "$db" < "$f" \
-                || { err "Migration failed: $f"; return 1; }
+                || { err "Migration failed: $f"; shopt -u nullglob; return 1; }
+            applied=$((applied + 1))
         done
     else
         local pguser pgdb
         pguser="$(read_env POSTGRES_USER nws_user)"
         pgdb="$(read_env POSTGRES_DB nws_cad)"
-        for f in $(ls "$dir"/*.pgsql.sql 2>/dev/null | sort); do
+        for f in "$dir"/*.pgsql.sql; do
             say "  migration: $f"
             docker exec -i nws-cad-postgres psql -U "$pguser" -d "$pgdb" -v ON_ERROR_STOP=1 -f - < "$f" \
-                || { err "Migration failed: $f"; return 1; }
+                || { err "Migration failed: $f"; shopt -u nullglob; return 1; }
+            applied=$((applied + 1))
         done
     fi
-    ok "Migrations applied."
+    shopt -u nullglob
+    if [ "$applied" -eq 0 ]; then
+        ok "No migrations to apply for $DB_TYPE."
+    else
+        ok "Migrations applied ($applied)."
+    fi
 }
 
 verify_health() {


### PR DESCRIPTION
## Summary

Adds push-to-deploy continuous deployment to a self-hosted host, plus the deploy automation the runbook previously described only as manual steps — and hardens the compose stack it deploys.

This is a **`feat`** (new CD capability) → minor release. No app/runtime code changes; everything here is ops tooling, compose config, and docs. Existing deployments are unaffected until they opt in (see *Rollout* below).

## What's in it

### 1. Continuous deployment (`feat`)
- **`.github/workflows/deploy.yml`** — CD triggered via `workflow_run` on the **Release** workflow completing. (`GITHUB_TOKEN`-created tags/releases don't fire `push:tags`/`release:published`, so `workflow_run` is the reliable hook — **no PAT required**.)
  - **`gate` job** (github-hosted, no approval): only proceeds when a release was actually cut — the tip of `main` is a `chore(release): vX.Y.Z` commit — so no-release pushes (docs/chores) never prompt for approval.
  - **`deploy` job** (self-hosted `[self-hosted, nws-cad]`, `environment: production` with a required reviewer): runs `scripts/deploy.sh` against the on-host clone at `${{ vars.DEPLOY_DIR }}` — deliberately **not** the runner's checkout dir, which has no `.env`/`var/data`. Supports manual dispatch + rollback (`ref` + `force`).
- **`scripts/deploy.sh`** — one-command deploy of a target release, runnable by hand *or* by CI. Automates the runbook end to end: pre-flight → DB backup (via `backup-database.sh` when a DB container is running) → `git checkout <tag>` → build → DB up + wait-for-ready → apply `database/migrations/*` for the active `DB_TYPE` → recreate stack → verify `/api/health` from inside the api container. **Rolls back** to the previous commit on any failure; **idempotent** (no-op unless `FORCE=1`); **self-reexec-safe** so a mid-run `git checkout` can't corrupt the running shell.
- **`docs/deployment/CD.md`** — one-time setup (runner registration + `nws-cad` label, the `production` Environment/approval gate, the `DEPLOY_DIR` variable), trigger-model rationale, and the run/rollback/host-fallback flows.

### 2. Compose stack hardening
- **Autoheal** — `willfarrell/autoheal` sidecar restarts any container labeled `autoheal=true` (`app`, `api`, `mysql`, `postgres`) when its healthcheck flips to **unhealthy** (wedged process that doesn't exit). Closes the open `TODO.md` item.
- **`api` restart policy** — added `restart: unless-stopped` (it was the only service missing one).
- **`BIND_ADDR`** — new knob (default `0.0.0.0`, behavior-preserving) to move the API/DB/Dozzle published ports to loopback-only (`127.0.0.1`) for production defense-in-depth with a single `.env` change.
- **Log rotation caps** — `json-file` `max-size 10m` / `max-file 3` on every service via a shared YAML anchor, so container logs can't fill the host disk.

## Verification
- `docker compose config` passes for both `mysql` and `pgsql` profiles; rendered output confirms `BIND_ADDR` override, autoheal presence, and log caps on all services.
- `deploy.sh`: `bash -n` clean; smoke-tested re-exec + path resolution + pre-flight (fails cleanly with no `.env`; temp copy cleaned up; no rollback triggered pre-start).
- `deploy.yml`: YAML validated (both jobs parse).
- Docker-daemon-dependent paths (live autoheal restart, full deploy run) can't execute in the CI sandbox and must be exercised on the host.

## Rollout (operator, one-time — see `docs/deployment/CD.md`)
1. Register a self-hosted runner on the host with the **`nws-cad`** label (runner user in the `docker` group, owning the clone).
2. Create the **`production`** Environment with a required reviewer (the approval gate).
3. Set the **`DEPLOY_DIR`** variable to the host clone path (e.g. `/opt/nws-cad`).

Nothing here is production-breaking on upgrade: the port-bind default is preserved and the new services/scripts are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8BSZ2SVGEaLo5zqTKfKvZ)_