### PR TITLE
fix(import): accept &lt;Call&gt; root element in XmlValidator (real Aegis feed)

### DIFF
--- a/src/Import/XmlValidator.php
+++ b/src/Import/XmlValidator.php
@@ -15,7 +15,8 @@ use SimpleXMLElement;
  * front, before any transaction is opened, with a clear {@see InvalidXmlException}.
  *
  * Scope is intentionally behavior-preserving: it requires only what already
- * caused an ingest to fail — a `CallExport` root and non-empty `CallId` /
+ * caused an ingest to fail — a recognized call root (`Call`, as emitted by the
+ * real Aegis feed, or the legacy `CallExport`) and non-empty `CallId` /
  * `CallNumber` (both NOT NULL in the schema with no parser-side fallback).
  * `CreateDateTime` is NOT required here because insertCall() defaults a missing
  * value to "now"; requiring it would reject input the importer currently
@@ -24,20 +25,30 @@ use SimpleXMLElement;
  */
 final class XmlValidator
 {
-    private const ROOT_ELEMENT = 'CallExport';
+    /**
+     * Accepted document root elements. Real Aegis CAD exports use `<Call>` (the
+     * element that carries CallId/CallNumber/AgencyContexts/AssignedUnits/etc.
+     * directly). `<CallExport>` is accepted too for backward compatibility with
+     * older/synthetic documents. The importer reads every field as a direct
+     * child of whichever root is present, so both shapes map identically.
+     *
+     * @var string[]
+     */
+    private const ROOT_ELEMENTS = ['Call', 'CallExport'];
 
     /** Fields whose absence already fails the insert (schema NOT NULL, no fallback). */
     private const REQUIRED_FIELDS = ['CallId', 'CallNumber'];
 
     /**
-     * @throws InvalidXmlException if the document is not a usable CallExport.
+     * @throws InvalidXmlException if the document is not a usable Aegis call export.
      */
     public function validate(SimpleXMLElement $xml): void
     {
         $root = $xml->getName();
-        if ($root !== self::ROOT_ELEMENT) {
+        if (!in_array($root, self::ROOT_ELEMENTS, true)) {
             throw new InvalidXmlException(
-                "Unexpected root element <{$root}>, expected <" . self::ROOT_ELEMENT . '>'
+                "Unexpected root element <{$root}>, expected one of <"
+                . implode('>, <', self::ROOT_ELEMENTS) . '>'
             );
         }
 

--- a/tests/Unit/XmlValidatorTest.php
+++ b/tests/Unit/XmlValidatorTest.php
@@ -32,6 +32,17 @@ class XmlValidatorTest extends TestCase
         );
     }
 
+    public function testCallRootPasses(): void
+    {
+        // Real Aegis CAD exports are rooted at <Call>, not <CallExport>.
+        // Requiring <CallExport> (matching the synthetic fixtures) silently
+        // rejected every live document — guard against that regression.
+        $this->expectNotToPerformAssertions();
+        (new XmlValidator())->validate(
+            $this->xml('<CallId>1938439</CallId><CallNumber>104</CallNumber>', 'Call')
+        );
+    }
+
     public function testWrongRootIsRejected(): void
     {
         $this->expectException(InvalidXmlException::class);


### PR DESCRIPTION
## Summary

Production ingestion silently stopped: **every** live file failed with `Unexpected root element <Call>, expected <CallExport>` and was moved to `failed/`, so no calls were imported (a ~10-hour outage on the `nws` deployment).

Real Aegis CAD exports are rooted at **`<Call>`** — the element that carries `CallId`/`CallNumber`/`AgencyContexts`/`AssignedUnits`/`Location`/`Narratives`/etc. as direct children. The `XmlValidator` added during the importer decomposition hard-required a `<CallExport>` root, which only ever matched the **synthetic test fixtures** (all 33 fixtures use `<CallExport>`). So the "behavior-preserving" validation was in fact a regression that rejected every real document once deployed.

## Fix

- `XmlValidator` now accepts **both** `<Call>` (real feed) and `<CallExport>` (legacy/fixtures). The importer reads all fields as direct children of whichever root is present, so both shapes map identically — no mapper changes needed.
- Added a `<Call>`-root acceptance test in `XmlValidatorTest` as a regression guard.

## Verification

- Standalone validation run: real `<Call>` doc → **passes**; `<CallExport>` → **passes**; bogus root → **rejected**; missing `CallId` → **rejected**.
- Existing `XmlValidatorTest` cases stay green (the wrong-root message assertion still matches; both fixture roots accepted).
- Confirmed live on the affected host: after applying this file, the watcher logs `Processing file:` / `Scan complete: N processed` with **zero** `Error processing file`, and the backlog began draining.

## Impact

Behavior change is strictly additive (one more accepted root). No schema or API changes. This restores ingestion for standard Aegis `<Call>` exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8BSZ2SVGEaLo5zqTKfKvZ)_