### PR TITLE
feat: add System Status modal with disk and server health

### DIFF
--- a/public/api.php
+++ b/public/api.php
@@ -33,6 +33,9 @@ $router = new Router('/api');
 // Health Check Route (used by docker-compose api healthcheck)
 $router->get('/health', [HealthController::class, 'index']);
 
+// Extended system health (version, disk, memory, load, watcher, outbox)
+$router->get('/health/system', [HealthController::class, 'system']);
+
 // Filter Options Route
 $router->get('/filter-options', [FilterOptionsController::class, 'index']);
 
@@ -49,6 +52,7 @@ $router->get('/', function() {
             'stats' => '/api/stats',
             'notifications' => '/api/notifications/channels',
             'health' => '/api/health',
+            'health_system' => '/api/health/system',
             'docs' => '/api/docs'
         ]
     ]);

--- a/public/assets/css/dashboard.css
+++ b/public/assets/css/dashboard.css
@@ -672,6 +672,11 @@ Timestamp: Wed Jan 28 01:35:28 UTC 2026
 }
 .live-pill.is-paused .dot { background: #94a3b8; animation: none; box-shadow: none; }
 .live-pill.is-error  .dot { background: #f87171; animation: none; box-shadow: none; }
+/* Health-driven light (green/yellow/red) — fed by /api/health/system. Declared
+   after is-paused/is-error so, at equal specificity, health wins for the dot. */
+.live-pill.is-health-ok .dot       { background: #22c55e; box-shadow: 0 0 6px rgba(34, 197, 94, 0.9); animation: live-pulse 1.6s infinite; }
+.live-pill.is-health-warn .dot     { background: #eab308; box-shadow: 0 0 6px rgba(234, 179, 8, 0.9);  animation: none; }
+.live-pill.is-health-critical .dot { background: #ef4444; box-shadow: 0 0 6px rgba(239, 68, 68, 0.9);  animation: none; }
 /* Clickable variant (opens the System Status modal) — resets native button chrome */
 .live-pill-btn { cursor: pointer; line-height: 1.2; font: inherit; font-size: 0.8rem; font-weight: 500; }
 .live-pill-btn:hover,

--- a/public/assets/css/dashboard.css
+++ b/public/assets/css/dashboard.css
@@ -672,6 +672,33 @@ Timestamp: Wed Jan 28 01:35:28 UTC 2026
 }
 .live-pill.is-paused .dot { background: #94a3b8; animation: none; box-shadow: none; }
 .live-pill.is-error  .dot { background: #f87171; animation: none; box-shadow: none; }
+/* Clickable variant (opens the System Status modal) — resets native button chrome */
+.live-pill-btn { cursor: pointer; line-height: 1.2; font: inherit; font-size: 0.8rem; font-weight: 500; }
+.live-pill-btn:hover,
+.live-pill-btn:focus-visible { background: rgba(255, 255, 255, 0.30); outline: none; }
+.live-pill-btn:focus-visible { box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.6); }
+
+/* Footer API-status badge rendered as a button (opens System Status modal) */
+#api-status { cursor: pointer; border: 0; font: inherit; line-height: 1; padding: 0.35em 0.65em; }
+
+/* System Status modal layout */
+.system-status-section { margin-bottom: 1.1rem; }
+.system-status-section:last-child { margin-bottom: 0; }
+.system-status-heading {
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: #64748b;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.3rem;
+    border-bottom: 1px solid rgba(100, 116, 139, 0.18);
+}
+.system-status-item { margin-bottom: 0.85rem; }
+.system-status-item:last-child { margin-bottom: 0; }
+.system-status-kv { padding: 0.25rem 0; }
+.system-status-kv + .system-status-kv { border-top: 1px solid rgba(100, 116, 139, 0.12); }
+.system-status-meter { height: 0.6rem; border-radius: 999px; }
 @keyframes live-pulse {
     0%   { box-shadow: 0 0 6px rgba(0, 230, 118, 0.9), 0 0 0 0 rgba(0, 230, 118, 0.85); }
     70%  { box-shadow: 0 0 6px rgba(0, 230, 118, 0.9), 0 0 0 12px rgba(0, 230, 118, 0); }

--- a/public/assets/js/dashboard-main.js
+++ b/public/assets/js/dashboard-main.js
@@ -84,6 +84,8 @@
             } else {
                 text.textContent = 'Live';
             }
+            const liveStatus = document.getElementById('dashboard-live-status');
+            if (liveStatus) liveStatus.textContent = text.textContent;
         }
 
         if (managers.MapManager) {

--- a/public/assets/js/dashboard.js
+++ b/public/assets/js/dashboard.js
@@ -669,6 +669,8 @@ const Dashboard = {
             pill.classList.add('is-paused');
             text.textContent = 'Paused';
         }
+        const liveStatus = document.getElementById('dashboard-live-status');
+        if (liveStatus) liveStatus.textContent = text.textContent;
     }
 };
 

--- a/public/assets/js/system-status.js
+++ b/public/assets/js/system-status.js
@@ -16,6 +16,38 @@
         return;
     }
 
+    // Navbar "status light": color the live pill by overall system health.
+    const pill = document.getElementById('dashboard-live-pill');
+    const HEALTH_CLASSES = ['is-health-ok', 'is-health-warn', 'is-health-critical'];
+    const HEALTH_TITLE = {
+        ok:       'System health: OK — click for details',
+        warn:     'System health: Warning — click for details',
+        critical: 'System health: Critical — click for details',
+    };
+    const POLL_INTERVAL_MS = 60000;
+
+    function applyPillHealth(status) {
+        if (!pill) return;
+        pill.classList.remove(...HEALTH_CLASSES);
+        const key = HEALTH_TITLE[status] ? status : 'critical';
+        pill.classList.add(`is-health-${key}`);
+        pill.title = HEALTH_TITLE[key];
+    }
+
+    // Lightweight background poll (own fetch, so it never triggers the global
+    // Dashboard error toast). Drives only the navbar light.
+    async function pollPillHealth() {
+        if (!pill) return;
+        try {
+            const res = await fetch(`${Dashboard.config.apiBaseUrl}/health/system`, { cache: 'no-cache' });
+            const body = await res.json();
+            if (!res.ok || !body || !body.success) throw new Error('unhealthy');
+            applyPillHealth(body.data && body.data.status);
+        } catch (err) {
+            applyPillHealth('critical');
+        }
+    }
+
     const els = {
         loading: document.getElementById('system-status-loading'),
         content: document.getElementById('system-status-content'),
@@ -158,10 +190,11 @@
 
         els.content.innerHTML = parts.join('');
 
-        // Overall badge + timestamp
+        // Overall badge + timestamp (and keep the navbar light in sync)
         const meta = statusMeta(data.status);
         els.overall.className = `badge ${meta.cls}`;
         els.overall.textContent = meta.label;
+        applyPillHealth(data.status);
         if (data.timestamp) {
             const dt = new Date(data.timestamp);
             els.timestamp.textContent = isNaN(dt.getTime())
@@ -201,4 +234,8 @@
     if (els.refresh) {
         els.refresh.addEventListener('click', load);
     }
+
+    // Start the navbar health light: poll now, then on an interval.
+    pollPillHealth();
+    setInterval(pollPillHealth, POLL_INTERVAL_MS);
 })();

--- a/public/assets/js/system-status.js
+++ b/public/assets/js/system-status.js
@@ -1,0 +1,204 @@
+/**
+ * System Status modal controller.
+ *
+ * Populates #system-status-modal from GET /api/health/system when the modal is
+ * opened (via the navbar live pill, the footer API-status badge, or the footer
+ * version label). All CAD/host-derived strings are rendered through
+ * Dashboard.safeHtml so nothing is interpolated into the DOM unescaped.
+ *
+ * @version 1.0.0
+ */
+(function () {
+    'use strict';
+
+    const modal = document.getElementById('system-status-modal');
+    if (!modal || typeof Dashboard === 'undefined') {
+        return;
+    }
+
+    const els = {
+        loading: document.getElementById('system-status-loading'),
+        content: document.getElementById('system-status-content'),
+        error: document.getElementById('system-status-error'),
+        overall: document.getElementById('system-status-overall'),
+        timestamp: document.getElementById('system-status-timestamp'),
+        refresh: document.getElementById('system-status-refresh'),
+    };
+
+    // status keyword -> Bootstrap badge/meter colour + label
+    const STATUS_META = {
+        ok:       { cls: 'bg-success',   bar: 'bg-success',   label: 'OK' },
+        warn:     { cls: 'bg-warning text-dark', bar: 'bg-warning', label: 'Warning' },
+        critical: { cls: 'bg-danger',    bar: 'bg-danger',    label: 'Critical' },
+        unknown:  { cls: 'bg-secondary', bar: 'bg-secondary', label: 'Unknown' },
+    };
+
+    function statusMeta(status) {
+        return STATUS_META[status] || STATUS_META.unknown;
+    }
+
+    function formatBytes(bytes) {
+        if (bytes === null || bytes === undefined || isNaN(bytes)) return '—';
+        if (bytes === 0) return '0 B';
+        const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+        const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+        const value = bytes / Math.pow(1024, i);
+        return `${value.toFixed(value >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+    }
+
+    function statusBadge(status) {
+        const meta = statusMeta(status);
+        return Dashboard.safeHtml`<span class="badge ${meta.cls}">${meta.label}</span>`;
+    }
+
+    // A labelled usage meter (disk / memory).
+    function meterRow(label, sub, usedPct, status) {
+        const meta = statusMeta(status);
+        const pct = (usedPct === null || usedPct === undefined) ? null : Math.max(0, Math.min(100, usedPct));
+        const bar = pct === null
+            ? Dashboard.safeHtml`<div class="text-muted small">Not available</div>`
+            : Dashboard.safeHtml`
+                <div class="progress system-status-meter" role="progressbar"
+                     aria-valuenow="${String(pct)}" aria-valuemin="0" aria-valuemax="100">
+                    <div class="progress-bar ${Dashboard.raw(meta.bar)}" style="width: ${String(pct)}%"></div>
+                </div>`;
+        return Dashboard.safeHtml`
+            <div class="system-status-item">
+                <div class="d-flex justify-content-between align-items-baseline">
+                    <span class="fw-semibold">${label}</span>
+                    <span>${Dashboard.raw(statusBadge(status))}</span>
+                </div>
+                <div class="text-muted small mb-1">${sub}</div>
+                ${Dashboard.raw(bar)}
+                <div class="text-muted small mt-1">${pct === null ? '—' : pct + '% used'}</div>
+            </div>`;
+    }
+
+    function kvRow(label, value, status) {
+        const badge = status ? Dashboard.raw(statusBadge(status)) : '';
+        return Dashboard.safeHtml`
+            <div class="d-flex justify-content-between align-items-baseline system-status-kv">
+                <span class="text-muted">${label}</span>
+                <span class="fw-semibold">${value} ${badge}</span>
+            </div>`;
+    }
+
+    function render(data) {
+        const parts = [];
+
+        // Version / app block
+        const app = data.app || {};
+        parts.push(Dashboard.safeHtml`
+            <div class="system-status-section">
+                <h6 class="system-status-heading"><i class="bi bi-tag"></i> Version</h6>
+                ${Dashboard.raw(kvRow('Application', 'v' + (app.version || 'unknown')))}
+                ${Dashboard.raw(kvRow('PHP', app.php_version || '—'))}
+                ${Dashboard.raw(kvRow('Environment', app.environment || '—'))}
+            </div>`);
+
+        // Disks
+        const disks = Array.isArray(data.disks) ? data.disks : [];
+        const diskMeters = disks.length
+            ? disks.map(d => meterRow(
+                d.label || 'Disk',
+                `${formatBytes(d.free_bytes)} free of ${formatBytes(d.total_bytes)}`,
+                d.used_pct,
+                d.status
+            )).join('')
+            : Dashboard.safeHtml`<div class="text-muted small">No disk information available.</div>`;
+        parts.push(Dashboard.safeHtml`
+            <div class="system-status-section">
+                <h6 class="system-status-heading"><i class="bi bi-hdd"></i> Disk</h6>
+                ${Dashboard.raw(diskMeters)}
+            </div>`);
+
+        // Memory
+        const mem = data.memory || {};
+        const memSub = mem.limit_bytes
+            ? `${formatBytes(mem.php_usage_bytes)} of ${formatBytes(mem.limit_bytes)} (peak ${formatBytes(mem.php_peak_bytes)})`
+            : `${formatBytes(mem.php_usage_bytes)} used (peak ${formatBytes(mem.php_peak_bytes)}, no limit)`;
+        parts.push(Dashboard.safeHtml`
+            <div class="system-status-section">
+                <h6 class="system-status-heading"><i class="bi bi-memory"></i> Memory (PHP)</h6>
+                ${Dashboard.raw(meterRow('PHP process', memSub, mem.used_pct, mem.status))}
+            </div>`);
+
+        // Server: db, load, watcher, outbox
+        const db = data.db || {};
+        const dbValue = db.latency_ms !== null && db.latency_ms !== undefined
+            ? `${db.latency_ms} ms`
+            : 'unreachable';
+        const serverRows = [kvRow('Database', dbValue, db.status)];
+
+        const load = data.load;
+        if (load) {
+            const cpus = load.cpus ? ` (${load.cpus} CPU${load.cpus === 1 ? '' : 's'})` : '';
+            serverRows.push(kvRow('Load avg', `${load['1m']} / ${load['5m']} / ${load['15m']}${cpus}`));
+        }
+
+        const watcher = data.watcher || {};
+        const watcherValue = watcher.heartbeat_age_seconds === null || watcher.heartbeat_age_seconds === undefined
+            ? 'no heartbeat'
+            : `${watcher.heartbeat_age_seconds}s ago`;
+        serverRows.push(kvRow('File watcher', watcherValue, watcher.status));
+
+        const outbox = data.outbox;
+        if (outbox) {
+            serverRows.push(kvRow(
+                'Notification outbox',
+                `${outbox.pending} pending · ${outbox.in_flight} in-flight · ${outbox.failed} failed`
+            ));
+        }
+
+        parts.push(Dashboard.safeHtml`
+            <div class="system-status-section">
+                <h6 class="system-status-heading"><i class="bi bi-hdd-network"></i> Server</h6>
+                ${Dashboard.raw(serverRows.join(''))}
+            </div>`);
+
+        els.content.innerHTML = parts.join('');
+
+        // Overall badge + timestamp
+        const meta = statusMeta(data.status);
+        els.overall.className = `badge ${meta.cls}`;
+        els.overall.textContent = meta.label;
+        if (data.timestamp) {
+            const dt = new Date(data.timestamp);
+            els.timestamp.textContent = isNaN(dt.getTime())
+                ? ''
+                : `Updated ${dt.toLocaleTimeString()}`;
+        }
+    }
+
+    function setLoading() {
+        els.loading.classList.remove('d-none');
+        els.content.classList.add('d-none');
+        els.error.classList.add('d-none');
+        els.overall.className = 'badge bg-secondary';
+        els.overall.textContent = 'Loading…';
+        els.timestamp.textContent = '';
+    }
+
+    async function load() {
+        setLoading();
+        try {
+            const data = await Dashboard.apiRequest('/health/system');
+            if (!data) throw new Error('empty response');
+            render(data);
+            els.loading.classList.add('d-none');
+            els.content.classList.remove('d-none');
+        } catch (err) {
+            console.error('[SystemStatus] load failed:', err);
+            els.loading.classList.add('d-none');
+            els.content.classList.add('d-none');
+            els.error.classList.remove('d-none');
+            els.overall.className = 'badge bg-danger';
+            els.overall.textContent = 'Error';
+        }
+    }
+
+    modal.addEventListener('show.bs.modal', load);
+    if (els.refresh) {
+        els.refresh.addEventListener('click', load);
+    }
+})();

--- a/public/index.php
+++ b/public/index.php
@@ -25,6 +25,10 @@ $apiBaseUrl = 'http://localhost:8080/api';
 // Get Dozzle port from environment (default 8081 - external Dozzle container)
 $dozzlePort = getenv('DOZZLE_PORT') ?: '8081';
 
+// App version (source of truth is the repo-root VERSION file, written by the
+// release workflow). Shown in the footer and the System Status modal.
+$appVersion = trim((string) @file_get_contents(__DIR__ . '/../VERSION')) ?: 'dev';
+
 // Define routes (dashboard-only)
 $routes = [
     '/' => 'dashboard',
@@ -100,10 +104,13 @@ $pageTitle = ucfirst(str_replace('-mobile', '', $page));
                     </li>
                 </ul>
                 <div class="d-flex align-items-center">
-                    <span class="live-pill" id="dashboard-live-pill" role="status" aria-live="polite">
+                    <button type="button" class="live-pill live-pill-btn" id="dashboard-live-pill"
+                            data-bs-toggle="modal" data-bs-target="#system-status-modal"
+                            title="View system status" aria-label="View system status">
                         <span class="dot" aria-hidden="true"></span>
                         <span id="dashboard-live-text">Live</span>
-                    </span>
+                    </button>
+                    <span class="visually-hidden" id="dashboard-live-status" role="status" aria-live="polite">Live</span>
                 </div>
             </div>
         </div>
@@ -121,13 +128,21 @@ $pageTitle = ucfirst(str_replace('-mobile', '', $page));
         ?>
     </main>
 
+    <!-- System Status modal (version + disk/server health) — shared across all pages -->
+    <?php include __DIR__ . '/../src/Dashboard/Views/partials/system-status-modal.php'; ?>
+
     <!-- Footer -->
     <footer class="bg-light py-3 mt-5 no-print">
         <div class="container-fluid text-center text-muted">
             <small>
-                NWS CAD Dashboard &copy; <?= date('Y') ?> | 
+                NWS CAD Dashboard &copy; <?= date('Y') ?> |
                 <a href="https://github.com/k9barry/nws-cad" target="_blank">Documentation</a> |
-                API Status: <span id="api-status" class="badge bg-secondary">Checking...</span>
+                API Status: <button type="button" id="api-status" class="badge bg-secondary border-0"
+                        data-bs-toggle="modal" data-bs-target="#system-status-modal"
+                        title="View system status">Checking...</button> |
+                <button type="button" class="btn btn-link btn-sm p-0 align-baseline"
+                        data-bs-toggle="modal" data-bs-target="#system-status-modal"
+                        title="View system status">v<?= htmlspecialchars($appVersion) ?></button>
             </small>
         </div>
     </footer>
@@ -185,7 +200,9 @@ $pageTitle = ucfirst(str_replace('-mobile', '', $page));
         console.log('APP_CONFIG initialized:', window.APP_CONFIG);
     </script>
     <script src="/assets/js/dashboard.js?v=<?= time() ?>"></script>
-    
+    <!-- System Status modal controller (shared across all pages) -->
+    <script src="/assets/js/system-status.js?v=<?= time() ?>"></script>
+
     <?php if ($isMobile): ?>
     <!-- Mobile-specific scripts -->
     <script src="/assets/js/mobile.js?v=<?= time() ?>"></script>

--- a/src/Api/Controllers/HealthController.php
+++ b/src/Api/Controllers/HealthController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NwsCad\Api\Controllers;
 
 use NwsCad\Api\Response;
+use NwsCad\Config;
 use NwsCad\Database;
 use PDO;
 use Throwable;
@@ -12,6 +13,18 @@ use Throwable;
 final class HealthController
 {
     private PDO $db;
+
+    /** Disk usage warn/critical thresholds (percent used). */
+    private const DISK_WARN_PCT     = 80.0;
+    private const DISK_CRITICAL_PCT = 90.0;
+
+    /** PHP memory usage warn/critical thresholds (percent of limit). */
+    private const MEM_WARN_PCT     = 80.0;
+    private const MEM_CRITICAL_PCT = 95.0;
+
+    /** Watcher heartbeat staleness thresholds (seconds). */
+    private const HEARTBEAT_WARN_SECONDS     = 60;
+    private const HEARTBEAT_CRITICAL_SECONDS = 300;
 
     public function __construct()
     {
@@ -34,5 +47,329 @@ final class HealthController
         } catch (Throwable $e) {
             Response::error('Database unreachable', 503, ['db' => 'unreachable']);
         }
+    }
+
+    /**
+     * Extended system health: app version, DB latency, disk usage, PHP memory,
+     * load average, file-watcher heartbeat, and notification-outbox backlog.
+     *
+     * Every metric is best-effort and degrades gracefully (null / "unknown")
+     * so the endpoint never fails just because one probe is unavailable on a
+     * given host (e.g. sys_getloadavg() on non-Linux).
+     */
+    public function system(): void
+    {
+        $config = Config::getInstance();
+
+        $db      = $this->probeDatabase();
+        $disks   = $this->probeDisks($config);
+        $memory  = $this->probeMemory();
+        $load    = $this->probeLoad();
+        $watcher = $this->probeWatcher($config);
+        $outbox  = $this->probeOutbox();
+
+        // Overall status = worst of the sections that carry a status.
+        // "unknown" is informational and never drives the overall verdict.
+        $statuses = [
+            $db['status'],
+            $memory['status'],
+            $watcher['status'],
+        ];
+        foreach ($disks as $disk) {
+            $statuses[] = $disk['status'];
+        }
+
+        Response::success([
+            'status'    => $this->worstStatus($statuses),
+            'timestamp' => date('c'),
+            'app'       => [
+                'version'     => $this->appVersion(),
+                'php_version' => PHP_VERSION,
+                'environment' => (string) $config->get('app.env', 'production'),
+            ],
+            'db'      => $db,
+            'disks'   => $disks,
+            'memory'  => $memory,
+            'load'    => $load,
+            'watcher' => $watcher,
+            'outbox'  => $outbox,
+        ]);
+    }
+
+    /**
+     * @return array{status:string,latency_ms:float|null}
+     */
+    private function probeDatabase(): array
+    {
+        try {
+            $start = microtime(true);
+            $row   = $this->db->query('SELECT 1 AS ok')->fetch(PDO::FETCH_ASSOC);
+            $ms    = round((microtime(true) - $start) * 1000, 2);
+
+            if (!$row || (int) ($row['ok'] ?? 0) !== 1) {
+                return ['status' => 'critical', 'latency_ms' => null];
+            }
+            return ['status' => 'ok', 'latency_ms' => $ms];
+        } catch (Throwable $e) {
+            return ['status' => 'critical', 'latency_ms' => null];
+        }
+    }
+
+    /**
+     * Disk usage for the data (watch) and log volumes. Duplicate mounts are
+     * collapsed so a shared volume is reported once.
+     *
+     * @return list<array{label:string,path:string,total_bytes:int|null,free_bytes:int|null,used_bytes:int|null,used_pct:float|null,status:string}>
+     */
+    private function probeDisks(Config $config): array
+    {
+        $candidates = [
+            'Data (watch)' => (string) $config->get('watcher.folder', ''),
+            'Logs'         => (string) $config->get('paths.logs', ''),
+        ];
+
+        $disks = [];
+        $seen  = [];
+        foreach ($candidates as $label => $path) {
+            if ($path === '' || !is_dir($path)) {
+                continue;
+            }
+            $total = @disk_total_space($path);
+            $free  = @disk_free_space($path);
+            if ($total === false || $free === false || $total <= 0) {
+                $disks[] = [
+                    'label'       => $label,
+                    'path'        => $path,
+                    'total_bytes' => null,
+                    'free_bytes'  => null,
+                    'used_bytes'  => null,
+                    'used_pct'    => null,
+                    'status'      => 'unknown',
+                ];
+                continue;
+            }
+
+            // Collapse identical mounts (same total+free) reported under two paths.
+            $key = (int) $total . ':' . (int) $free;
+            if (isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+
+            $used    = $total - $free;
+            $usedPct = round(($used / $total) * 100, 1);
+
+            $disks[] = [
+                'label'       => $label,
+                'path'        => $path,
+                'total_bytes' => (int) $total,
+                'free_bytes'  => (int) $free,
+                'used_bytes'  => (int) $used,
+                'used_pct'    => $usedPct,
+                'status'      => $this->thresholdStatus($usedPct, self::DISK_WARN_PCT, self::DISK_CRITICAL_PCT),
+            ];
+        }
+
+        return $disks;
+    }
+
+    /**
+     * @return array{php_usage_bytes:int,php_peak_bytes:int,limit_bytes:int|null,used_pct:float|null,status:string}
+     */
+    private function probeMemory(): array
+    {
+        $usage = memory_get_usage(true);
+        $peak  = memory_get_peak_usage(true);
+        $limit = $this->parseBytes((string) ini_get('memory_limit'));
+
+        $usedPct = null;
+        $status  = 'ok';
+        if ($limit !== null && $limit > 0) {
+            $usedPct = round(($usage / $limit) * 100, 1);
+            $status  = $this->thresholdStatus($usedPct, self::MEM_WARN_PCT, self::MEM_CRITICAL_PCT);
+        }
+
+        return [
+            'php_usage_bytes' => $usage,
+            'php_peak_bytes'  => $peak,
+            'limit_bytes'     => $limit,
+            'used_pct'        => $usedPct,
+            'status'          => $status,
+        ];
+    }
+
+    /**
+     * @return array{1m:float,5m:float,15m:float,cpus:int|null}|null
+     */
+    private function probeLoad(): ?array
+    {
+        if (!function_exists('sys_getloadavg')) {
+            return null;
+        }
+        $load = @sys_getloadavg();
+        if (!is_array($load) || count($load) < 3) {
+            return null;
+        }
+
+        return [
+            '1m'   => round((float) $load[0], 2),
+            '5m'   => round((float) $load[1], 2),
+            '15m'  => round((float) $load[2], 2),
+            'cpus' => $this->cpuCount(),
+        ];
+    }
+
+    /**
+     * @return array{heartbeat_age_seconds:int|null,threshold_seconds:int,status:string}
+     */
+    private function probeWatcher(Config $config): array
+    {
+        $logDir = rtrim((string) $config->get('paths.logs', ''), '/');
+        $path   = $logDir !== '' ? $logDir . '/.watcher-heartbeat' : '';
+
+        if ($path === '' || !is_file($path)) {
+            return [
+                'heartbeat_age_seconds' => null,
+                'threshold_seconds'     => self::HEARTBEAT_WARN_SECONDS,
+                'status'                => 'unknown',
+            ];
+        }
+
+        $mtime = @filemtime($path);
+        if ($mtime === false) {
+            return [
+                'heartbeat_age_seconds' => null,
+                'threshold_seconds'     => self::HEARTBEAT_WARN_SECONDS,
+                'status'                => 'unknown',
+            ];
+        }
+
+        $age = max(0, time() - $mtime);
+        if ($age >= self::HEARTBEAT_CRITICAL_SECONDS) {
+            $status = 'critical';
+        } elseif ($age >= self::HEARTBEAT_WARN_SECONDS) {
+            $status = 'warn';
+        } else {
+            $status = 'ok';
+        }
+
+        return [
+            'heartbeat_age_seconds' => $age,
+            'threshold_seconds'     => self::HEARTBEAT_WARN_SECONDS,
+            'status'                => $status,
+        ];
+    }
+
+    /**
+     * Notification-outbox backlog by status. Returns null if the table is
+     * absent (e.g. notifications module not provisioned).
+     *
+     * @return array{pending:int,in_flight:int,retry:int,done:int,failed:int,total:int}|null
+     */
+    private function probeOutbox(): ?array
+    {
+        try {
+            $rows = $this->db
+                ->query('SELECT status, COUNT(*) AS c FROM notification_outbox GROUP BY status')
+                ->fetchAll(PDO::FETCH_ASSOC);
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        $counts = ['pending' => 0, 'in_flight' => 0, 'retry' => 0, 'done' => 0, 'failed' => 0];
+        $total  = 0;
+        foreach ($rows as $row) {
+            $status = (string) ($row['status'] ?? '');
+            $count  = (int) ($row['c'] ?? 0);
+            $total += $count;
+            if (array_key_exists($status, $counts)) {
+                $counts[$status] = $count;
+            }
+        }
+        $counts['total'] = $total;
+
+        return $counts;
+    }
+
+    private function appVersion(): string
+    {
+        $file = __DIR__ . '/../../../VERSION';
+        if (is_file($file)) {
+            $version = trim((string) @file_get_contents($file));
+            if ($version !== '') {
+                return $version;
+            }
+        }
+        return 'unknown';
+    }
+
+    private function cpuCount(): ?int
+    {
+        $cpuinfo = '/proc/cpuinfo';
+        if (is_readable($cpuinfo)) {
+            $contents = @file_get_contents($cpuinfo);
+            if ($contents !== false) {
+                $count = preg_match_all('/^processor\s*:/m', $contents);
+                if ($count > 0) {
+                    return $count;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parse a PHP ini shorthand byte value ("256M", "1G", "-1", "512K").
+     * Returns null for unlimited (-1) or unparseable input.
+     */
+    private function parseBytes(string $value): ?int
+    {
+        $value = trim($value);
+        if ($value === '' || $value === '-1') {
+            return null;
+        }
+        if (!preg_match('/^(\d+)\s*([KMG]?)$/i', $value, $m)) {
+            return null;
+        }
+        $number = (int) $m[1];
+        switch (strtoupper($m[2])) {
+            case 'G':
+                return $number * 1024 * 1024 * 1024;
+            case 'M':
+                return $number * 1024 * 1024;
+            case 'K':
+                return $number * 1024;
+            default:
+                return $number;
+        }
+    }
+
+    private function thresholdStatus(float $pct, float $warn, float $critical): string
+    {
+        if ($pct >= $critical) {
+            return 'critical';
+        }
+        if ($pct >= $warn) {
+            return 'warn';
+        }
+        return 'ok';
+    }
+
+    /**
+     * @param list<string> $statuses
+     */
+    private function worstStatus(array $statuses): string
+    {
+        $rank = ['ok' => 0, 'unknown' => 0, 'warn' => 1, 'critical' => 2];
+        $worst = 'ok';
+        $worstRank = 0;
+        foreach ($statuses as $status) {
+            $r = $rank[$status] ?? 0;
+            if ($r > $worstRank) {
+                $worstRank = $r;
+                $worst = $status;
+            }
+        }
+        return $worst;
     }
 }

--- a/src/Api/Controllers/HealthController.php
+++ b/src/Api/Controllers/HealthController.php
@@ -199,7 +199,7 @@ final class HealthController
     }
 
     /**
-     * @return array{1m:float,5m:float,15m:float,cpus:int|null}|null
+     * @return array{'1m':float,'5m':float,'15m':float,cpus:int|null}|null
      */
     private function probeLoad(): ?array
     {

--- a/src/Api/Controllers/README.md
+++ b/src/Api/Controllers/README.md
@@ -294,6 +294,53 @@ Get detailed response time analysis.
 
 ---
 
+### 5. HealthController
+
+Liveness and extended system-health probes. Used by the Docker `api`
+healthcheck and by the dashboard **System Status** modal.
+
+#### Endpoints
+
+##### `GET /api/health` - Liveness
+
+Runs `SELECT 1`. Returns `{status:"ok", db:"ok", timestamp}` on success, or
+`503` with `{success:false, error:"Database unreachable"}` when the DB is down.
+
+##### `GET /api/health/system` - Extended System Health
+
+Best-effort host/app metrics for the System Status modal. Every probe degrades
+gracefully (null / `"unknown"`) so one unavailable metric never fails the call.
+Each section carries a status keyword (`ok` / `warn` / `critical` / `unknown`);
+the top-level `status` is the worst of the DB, disk, and memory sections.
+
+```
+GET /api/health/system
+{
+  "success": true,
+  "data": {
+    "status": "ok",
+    "timestamp": "2026-07-18T12:00:00+00:00",
+    "app":     { "version": "2.1.4", "php_version": "8.3.x", "environment": "production" },
+    "db":      { "status": "ok", "latency_ms": 1.4 },
+    "disks":   [ { "label": "Data (watch)", "path": "...", "total_bytes": 0,
+                   "free_bytes": 0, "used_bytes": 0, "used_pct": 63.2, "status": "ok" } ],
+    "memory":  { "php_usage_bytes": 0, "php_peak_bytes": 0, "limit_bytes": 0,
+                 "used_pct": 12.5, "status": "ok" },
+    "load":    { "1m": 0.4, "5m": 0.5, "15m": 0.6, "cpus": 4 },
+    "watcher": { "heartbeat_age_seconds": 3, "threshold_seconds": 60, "status": "ok" },
+    "outbox":  { "pending": 0, "in_flight": 0, "retry": 0, "done": 0, "failed": 0, "total": 0 }
+  }
+}
+```
+
+Thresholds: disk `warn` ≥ 80% / `critical` ≥ 90%; memory `warn` ≥ 80% /
+`critical` ≥ 95%; watcher heartbeat `warn` ≥ 60s / `critical` ≥ 300s. `load` is
+informational (Linux-only; `null` elsewhere). `outbox` is `null` if the
+notifications module is not provisioned. Disk figures reflect the container
+mount, not the physical host.
+
+---
+
 ## Common Response Formats
 
 ### Success Response (Single Item)

--- a/src/Dashboard/Views/partials/system-status-modal.php
+++ b/src/Dashboard/Views/partials/system-status-modal.php
@@ -1,0 +1,39 @@
+<!-- System Status Modal (version + disk/server health) -->
+<div class="modal fade" id="system-status-modal" tabindex="-1" aria-labelledby="systemStatusModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header gradient-card-header">
+                <div>
+                    <h5 class="modal-title" id="systemStatusModalLabel">
+                        <i class="bi bi-hdd-stack"></i> System Status
+                    </h5>
+                    <div class="small text-white-50">Version &amp; server health</div>
+                </div>
+                <div class="d-flex align-items-center gap-2">
+                    <span class="badge bg-secondary" id="system-status-overall">Loading…</span>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+            </div>
+            <div class="modal-body" id="system-status-body">
+                <div class="text-center text-muted py-5" id="system-status-loading">
+                    <span class="spinner-border spinner-border-sm"></span>
+                    Loading system status…
+                </div>
+                <div id="system-status-content" class="d-none"></div>
+                <div class="alert alert-danger d-none" id="system-status-error" role="alert">
+                    <i class="bi bi-exclamation-triangle"></i>
+                    Unable to load system status.
+                </div>
+            </div>
+            <div class="modal-footer">
+                <span class="text-muted small me-auto" id="system-status-timestamp"></span>
+                <button type="button" class="btn btn-outline-primary btn-sm" id="system-status-refresh">
+                    <i class="bi bi-arrow-clockwise"></i> Refresh
+                </button>
+                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">
+                    <i class="bi bi-x-circle"></i> Close
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/tests/Integration/HealthEndpointTest.php
+++ b/tests/Integration/HealthEndpointTest.php
@@ -52,4 +52,42 @@ class HealthEndpointTest extends TestCase
             $payload['data']['timestamp']
         );
     }
+
+    public function testSystemReturnsExtendedHealthPayload(): void
+    {
+        $controller = new HealthController();
+        ob_start();
+        $controller->system();
+        $body = (string) ob_get_clean();
+        $payload = json_decode($body, true);
+
+        $this->assertIsArray($payload);
+        $this->assertTrue($payload['success']);
+
+        $data = $payload['data'];
+        $this->assertContains($data['status'], ['ok', 'warn', 'critical']);
+
+        // App / version block
+        $this->assertArrayHasKey('app', $data);
+        $this->assertArrayHasKey('version', $data['app']);
+        $this->assertSame(PHP_VERSION, $data['app']['php_version']);
+
+        // Database latency
+        $this->assertSame('ok', $data['db']['status']);
+        $this->assertIsNumeric($data['db']['latency_ms']);
+
+        // Disks is a list; memory is always present
+        $this->assertIsArray($data['disks']);
+        $this->assertArrayHasKey('php_usage_bytes', $data['memory']);
+        $this->assertArrayHasKey('status', $data['memory']);
+
+        // Watcher heartbeat section present with a known status keyword
+        $this->assertArrayHasKey('watcher', $data);
+        $this->assertContains($data['watcher']['status'], ['ok', 'warn', 'critical', 'unknown']);
+
+        $this->assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+\-]\d{2}:\d{2}$/',
+            $data['timestamp']
+        );
+    }
 }


### PR DESCRIPTION
## Summary

There was no System Health page — and no disk/server health card anywhere — so this adds one as a **combined "System Status" modal** rather than a new page. The modal shows the **app version** alongside **disk/server health**, and is opened by clicking any of the existing system-status indicators.

## Triggers

The modal opens from:
- the navbar **status light** (the live pill) — now a **green/yellow/red health light** (see below),
- the footer **API Status** badge, or
- a new footer **version label** (`vX.Y.Z`).

## Navbar health light (green / yellow / red)

The navbar live pill is polled from `GET /api/health/system` every 60s and colored by overall health: **green** = OK, **yellow** = warning (disk/memory high or watcher heartbeat stale), **red** = critical or API unreachable. The modal also re-syncs the light whenever it loads/refreshes. Connection-error still resolves to red.

## What the modal shows

- **Version** — app version (from the repo-root `VERSION` file), PHP version, environment.
- **Disk** — usage meter(s) for the watch-data and log volumes (dedup'd if the same mount): free / total / % used.
- **Memory (PHP)** — process usage vs `memory_limit`, with peak.
- **Server** — DB latency, load average (Linux-only), file-watcher heartbeat age, and notification-outbox backlog (pending / in-flight / failed).

Each section carries an `ok` / `warn` / `critical` / `unknown` status; the modal header shows an overall badge (worst of DB, disk, memory). Thresholds: disk **80/90%**, memory **80/95%**, watcher heartbeat **60/300s**.

## Changes

**Backend**
- `HealthController::system()` — new best-effort probes (DB latency, disk, memory, load, watcher heartbeat, outbox counts). Every probe degrades gracefully to `null`/`"unknown"` so one unavailable metric never fails the call. Native PHP only (no shell-outs); outbox count is skipped if the table is absent.
- `GET /api/health/system` route registered in `public/api.php`; added to the `/api/` info listing.

**Frontend**
- `src/Dashboard/Views/partials/system-status-modal.php` — shared modal markup, included once in `index.php` so it works on every page (desktop + mobile).
- `public/assets/js/system-status.js` — renders the modal via `Dashboard.apiRequest` + `Dashboard.safeHtml` (all host/CAD-derived strings escaped); runs the background health-light poller.
- `index.php` — live pill + API-status badge become modal triggers; new footer version label; live-region preserved as a hidden `role="status"` span.
- `dashboard.js` / `dashboard-main.js` — sync the hidden live-region text.
- CSS for the clickable pill/badge, the green/yellow/red health dot, and the modal meter layout.

**Docs / tests**
- `src/Api/Controllers/README.md` — documents both health endpoints and the thresholds.
- `tests/Integration/HealthEndpointTest.php` — asserts the extended payload shape.

No user-role/allowlist changes were made.

## Notes / caveats

- Disk figures reflect the **container mount**, not the physical host — labeled as such.
- `load` is Linux-only and returns `null` elsewhere; `outbox` is `null` when the notifications module isn't provisioned.
- Pure-logic helpers (byte parsing, thresholds, worst-status, memory/load probes) were smoke-tested locally via reflection; the DB-backed integration test runs in CI.

## Test plan

- [ ] `composer test` + `composer phpstan` (CI), including `HealthEndpointTest::testSystemReturnsExtendedHealthPayload`.
- [ ] Open the dashboard; click the health light, the API Status badge, and the version label — each opens the modal and populates all sections.
- [ ] Confirm the navbar light turns yellow/red when a volume is near full or the API is down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YUWiuKYz343UvULvFzLkc